### PR TITLE
Change KnODE to load from config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KNODE := java -Xmx10G -jar /Users/tauber/github/knode/target/knode-0.2.0-SNAPSHOT-standalone.jar
+KNODE := java -jar knode.jar
 
 # Fetch ontology files
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KNODE := java -jar knode.jar
+KNODE := java -Xmx10G -jar /Users/tauber/github/knode/target/knode-0.2.0-SNAPSHOT-standalone.jar
 
 # Fetch ontology files
 build:
@@ -36,6 +36,12 @@ build/ncbitaxon-obsolete.ttl: src/ncbitaxon-obsolete.py build/delnodes.dmp
 
 # Load data into KnoDE
 
+.PHONY: load
+load: knode.edn build/ncbitaxon.owl build/ncbitaxon-merged.ttl build/ncbitaxon-obsolete.ttl
+	$(KNODE) load-config $<
+
+# Old load methods
+
 .PHONY: load-ontie
 load-ontie: ontology/context.kn ontology/external.tsv ontology/predicates.tsv ontology/index.tsv ontology/templates.kn ontology/ontie.kn
 	$(KNODE) load ONTIE $^
@@ -61,7 +67,7 @@ load-mro: build/mro.owl
 
 # General tasks
 .PHONY: all
-all: load-ontie load-ncbitaxonomy load-chebi load-obi load-mro
+all: load
 
 .PHONY: clean
 clean:

--- a/knode.edn
+++ b/knode.edn
@@ -1,0 +1,53 @@
+{:project-name "ONTIE",
+ :resources
+ [{:idspace "ONTIE",
+   :label "Ontology for Immune Epitopes",
+   :title "Ontology for Immune Epitopes",
+   :description
+   "ONTIE includes a range of terms to support the Immune Epitope Database.",
+   :homepage "https://ontology.iedb.org",
+   :type :local-file,
+   :paths
+   ["ontology/context.kn"
+    "ontology/external.tsv"
+    "ontology/predicates.tsv"
+    "ontology/index.tsv"
+    "ontology/templates.kn"
+    "ontology/ontie.kn"]}
+  {:idspace "NCBITaxonomy",
+   :label "NCBI Taxonomy",
+   :title "NCBI Taxonomy",
+   :description
+   "The NCBI Taxonomy is a large and widely used resource for scientific classification of organisms.",
+   :homepage "https://www.ncbi.nlm.nih.gov/taxonomy",
+   :type :local-file,
+   :path "build/ncbitaxon.owl"}
+  {:idspace "NCBITaxonomy",
+   :type :local-file,
+   :path "build/ncbitaxon-merged.ttl"}
+  {:idspace "NCBITaxonomy",
+   :type :local-file,
+   :path "build/ncbitaxon-obsolete.ttl"}
+  {:idspace "MRO",
+   :label "MHC Restriction Ontology",
+   :title "MHC Restriction Ontology",
+   :description
+   "MRO is an ontology for representing Major Histocompatibility Complex (MHC) molecules as they relate to immunological experiments.",
+   :homepage "https://github.com/IEDB/MRO",
+   :type :local-file,
+   :path "build/mro.owl"}
+  {:idspace "ChEBI",
+   :label "Chemical Entities of Biological Interest",
+   :title "Chemical Entities of Biological Interest",
+   :description
+   "ChEBI is a freely available dictionary of molecular entities focused on ‘small’ chemical compounds.",
+   :homepage "https://www.ebi.ac.uk/chebi/",
+   :type :local-file,
+   :path "build/chebi.owl"}
+  {:idspace "OBI",
+   :label "Ontology for Biomedical Investigations",
+   :title "Ontology for Biomedical Investigations",
+   :description
+   "The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific.",
+   :homepage "http://obi-ontology.org",
+   :type :obo-published-owl}]}

--- a/test/http-test.py
+++ b/test/http-test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-import csv, http.client, json, logging, sys, re
+import csv, http.client, json, logging, os, sys, re, requests
 
-base = 'ontology.iedb.org'
-logging.basicConfig(level=logging.DEBUG)
+base = 'http://127.0.0.1:3210'
+logging.basicConfig(level=logging.INFO)
 
 def main(args):
 	'''Usage: ./http-test.py api.md'''
@@ -44,6 +44,12 @@ def run_tests(get_tests, post_tests):
 def get(path):
 	'''Perform a GET request on a path in ontology.iedb.org. Return the response 
 	as a string.'''
+	if 'localhost' in base or '127.0.0.1' in base:
+		# use requests for local
+		os.environ['NO_PROXY'] = '127.0.0.1'
+		r = requests.get(base + path)
+		return fix_result(r.content)
+	# use http client for HTTPS
 	c = http.client.HTTPSConnection(base, timeout=10)
 	c.request('GET', path)
 	resp = c.getresponse()
@@ -52,6 +58,12 @@ def get(path):
 def post(path, body):
 	'''Perform a POST request on a path in ontology.iedb.org with a body. Return
 	the response as a string.'''
+	if 'localhost' in base or '127.0.0.1' in base:
+		# use requests for local
+		os.environ['NO_PROXY'] = '127.0.0.1'
+		r = requests.post(base + path, body)
+		return fix_result(r.content)
+	# use http client for HTTPS
 	c = http.client.HTTPSConnection(base, timeout=10)
 	c.request('POST', path, body)
 	resp = c.getresponse()


### PR DESCRIPTION
Add `knode.edn` to load resources with new version of KnoDE. All resources except for NCBITaxonomy are loaded via remote links.