### PR TITLE
New terms from IEDB

### DIFF
--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -640,3 +640,6 @@ NCBITaxon:64320	Zika virus	owl:Class
 NCBITaxon:5478	[Candida] glabrata	owl:Class
 NCBITaxon:730	[Haemophilus] ducreyi	owl:Class
 NCBITaxon:32644	unidentified	owl:Class
+NCBITaxon:42789	Enterovirus D68	owl:Class
+NCBITaxon:10261	Fowlpox virus	owl:Class
+NCBITaxon:2169700	Pseudomonas virus PRD1	owl:Class

--- a/ontology/index.tsv
+++ b/ontology/index.tsv
@@ -3300,45 +3300,7 @@ ONTIE:0003298	Onchocerca volvulus protein (Onchocerca volvulus)	owl:Class
 ONTIE:0003299	type VII secretion protein EsxH (Mycobacterium tuberculosis)	owl:Class		
 ONTIE:0003300	phosphate ABC transporter substrate-binding protein (Mycobacterium tuberculosis)	owl:Class		
 ONTIE:0003301	ribosomal-protein-alanine acetyltransferase rimJ (Mycobacterium tuberculosis)	owl:Class		
-ONTIE:0003302	thiol:disulfide interchange protein (Mycobacterium tuberculosis)	owl:Class		
-ONTIE:0003303	mapping note	owl:AnnotationProperty		
-ONTIE:0003304	vaccination	owl:Class		
-ONTIE:0003305	exposure to substance without evidence for disease	owl:Class		
-ONTIE:0003306	occurrence of asymptomatic infection	owl:Class		
-ONTIE:0003307	documented exposure without evidence for disease	owl:Class		
-ONTIE:0003308	environmental exposure to endemic/ubiquitous agent without evidence for disease	owl:Class		
-ONTIE:0003309	no exposure	owl:Class		
-ONTIE:0003310	unknown	owl:Class		
-ONTIE:0003311	solid tissue transplantation	owl:Class		
-ONTIE:0003312	transfusion	owl:Class		
-ONTIE:0003313	occurrence of cancer associated with virus	owl:Class		
-ONTIE:0003314	administering substance in vivo	owl:Class		
-ONTIE:0003315	infectious challenge	owl:Class		
-ONTIE:0003316	transplantation or transfusion	owl:Class		
-ONTIE:0003317	occurrence of infectious disease	owl:Class		
-ONTIE:0003318	occurrence of allergy	owl:Class		
-ONTIE:0003319	occurence of autoimmune disease	owl:Class		
-ONTIE:0003320	occurrence of cancer	owl:Class		
-ONTIE:0003321	exposure with existing immune reactivity without evidence for disease	owl:Class		
-ONTIE:0003303	mapping note	owl:AnnotationProperty		
-ONTIE:0003304	vaccination	owl:Class		
-ONTIE:0003305	exposure to substance without evidence for disease	owl:Class		
-ONTIE:0003306	occurrence of asymptomatic infection	owl:Class		
-ONTIE:0003307	documented exposure without evidence for disease	owl:Class		
-ONTIE:0003308	environmental exposure to endemic/ubiquitous agent without evidence for disease	owl:Class		
-ONTIE:0003309	no exposure	owl:Class		
-ONTIE:0003310	unknown	owl:Class		
-ONTIE:0003311	solid tissue transplantation	owl:Class		
-ONTIE:0003312	transfusion	owl:Class		
-ONTIE:0003313	occurrence of cancer associated with virus	owl:Class		
-ONTIE:0003314	administering substance in vivo	owl:Class		
-ONTIE:0003315	infectious challenge	owl:Class		
-ONTIE:0003316	transplantation or transfusion	owl:Class		
-ONTIE:0003317	occurrence of infectious disease	owl:Class		
-ONTIE:0003318	occurrence of allergy	owl:Class		
-ONTIE:0003319	occurence of autoimmune disease	owl:Class		
-ONTIE:0003320	occurrence of cancer	owl:Class		
-ONTIE:0003321	exposure with existing immune reactivity without evidence for disease	owl:Class		
+ONTIE:0003302	thiol:disulfide interchange protein (Mycobacterium tuberculosis)	owl:Class			
 ONTIE:0003303	mapping note	owl:AnnotationProperty		
 ONTIE:0003304	vaccination	owl:Class		
 ONTIE:0003305	exposure to substance without evidence for disease	owl:Class		
@@ -3491,161 +3453,90 @@ ONTIE:0003451	Fowlpox virus FP9	owl:Class
 ONTIE:0003452	Salmonella enterica subsp. enterica serovar Typhi str. Quailes	owl:Class		
 ONTIE:0003453	Salmonella enterica subsp. enterica serovar Paratyphi A str. NVGH308	owl:Class		
 ONTIE:0003454	Enterobacteria phage PRD1	owl:Class		
-ONTIE:0003455	band 3 anion transport protein (Mus musculus)	owl:Class		
-ONTIE:0003456	ubiquitin-associated domain-containing protein 2 (Homo sapiens)	owl:Class		
-ONTIE:0003457	CD74/ROS (Homo sapiens)	owl:Class		
-ONTIE:0003458	cyclin-dependent kinase 3 (Homo sapiens)	owl:Class		
-ONTIE:0003459	Uncharacterized protein KIAA0754 (Homo sapiens)	owl:Class		
-ONTIE:0003460	Major Peanut Allergen Ara H 6 (Arachis hypogaea)	owl:Class		
-ONTIE:0003461	epsilon toxin (Clostridium perfringens)	owl:Class		
-ONTIE:0003462	DNA processivity factor (Human betaherpesvirus 5)	owl:Class		
-ONTIE:0003463	synuclein (Homo sapiens)	owl:Class		
-ONTIE:0003464	phospholipase A2 inhibitor gamma (Sinonatrix annularis)	owl:Class		
-ONTIE:0003465	phospholipase A2 inhibitor gamma (Macropisthodon rudis)	owl:Class		
-ONTIE:0003466	phospholipase A2 inhibitor gamma (Elaphe carinata)	owl:Class		
-ONTIE:0003467	phospholipase A2 inhibitor gamma (Ptyas dhumnades)	owl:Class		
-ONTIE:0003468	phospholipase A2 inhibitor gamma (Elaphe taeniura)	owl:Class		
-ONTIE:0003469	phospholipase A2 inhibitor gamma (Lycodon rufozonatus)	owl:Class		
-ONTIE:0003470	phospholipase A2 inhibitor gamma (Oocatochus rufodorsatus)	owl:Class		
-ONTIE:0003471	carbonate dehydratase (Mycobacterium tuberculosis)	owl:Class		
-ONTIE:0003472	glycoprotein G (Human alphaherpesvirus 1)	owl:Class		
-ONTIE:0003473	glycoprotein G (Human alphaherpesvirus 2)	owl:Class		
-ONTIE:0003474	holin (Salmonella enterica)	owl:Class		
-ONTIE:0003475	DNA polymerase III subunit gamma/tau (Salmonella enterica)	owl:Class		
-ONTIE:0003476	formate transporter FocA (Salmonella enterica)	owl:Class		
-ONTIE:0003477	phage baseplate protein (Salmonella enterica)	owl:Class		
-ONTIE:0003478	RNA helicase (Salmonella enterica)	owl:Class		
-ONTIE:0003479	valine tRNA ligase (Salmonella enterica)	owl:Class		
-ONTIE:0003480	hypothetical protein (Salmonella enterica)	owl:Class		
-ONTIE:0003481	PTS system mannitol-specific transporter subunit IIA (Salmonella enterica)	owl:Class		
-ONTIE:0003482	Zn-dependent protease (Salmonella enterica)	owl:Class		
-ONTIE:0003483	serine/threonine protein kinase (Salmonella enterica)	owl:Class		
-ONTIE:0003484	chloramphenicol/florfenicol efflux MFS transporter FloR (Salmonella enterica)	owl:Class		
-ONTIE:0003485	AraC family transcriptional regulator (Salmonella enterica)	owl:Class		
-ONTIE:0003486	glucosyltransferase (Salmonella enterica)	owl:Class		
-ONTIE:0003487	protein RarD (Salmonella enterica)	owl:Class		
-ONTIE:0003488	von Willebrand factor-cleaving protease precursor (Homo sapiens)	owl:Class		
-ONTIE:0003489	nucleocapsid protein (Canine morbillivirus)	owl:Class		
-ONTIE:0003490	Protocadherin-24 Ec1-3 (Mus musculus)	owl:Class		
-ONTIE:0003491	collagen alpha-3(VI) chain (Equus przewalskii)	owl:Class		
-ONTIE:0003492	Collagen alpha-1(VII) chain (Mus musculus)	owl:Class		
-ONTIE:0003493	MF6p ortholog protein (Paragonimus westermani)	owl:Class		
-ONTIE:0003494	ATP synthase subunit beta (Plasmodium berghei)	owl:Class		
-ONTIE:0003495	ubiquitin carboxyl-terminal hydrolase 47 (Mus musculus)	owl:Class		
-ONTIE:0003496	transcription factor 4 (Mus musculus)	owl:Class		
-ONTIE:0003497	anaphase-promoting complex (Mus musculus)	owl:Class		
-ONTIE:0003498	solute carrier family 2, facilitated glucose transporter member 7 (Mus musculus)	owl:Class		
-ONTIE:0003499	transmembrane protein vezatin (Homo sapiens)	owl:Class		
-ONTIE:0003500	Werner syndrome ATP-dependent helicase (Homo sapiens)	owl:Class		
-ONTIE:0003501	conserved Plasmodium protein (Plasmodium berghei)	owl:Class		
-ONTIE:0003502	hypothetical protein, conserved (Leishmania donovani)	owl:Class		
-ONTIE:0003503	potassium-transporting ATPase alpha chain 1 (Oryctolagus cuniculus)	owl:Class		
-ONTIE:0003504	NACHT and WD repeat domain-containing protein 2 (Rattus norvegicus)	owl:Class		
-ONTIE:0003505	collagen alpha-3(VI) chain (Mus musculus)	owl:Class		
-ONTIE:0003506	troponin T cardiac (Carassius auratus)	owl:Class		
-ONTIE:0003507	troponin T cardiac (Melospiza melodia)	owl:Class		
-ONTIE:0003508	Major surface glycoprotein G (Human respiratory syncytial virus A)	owl:Class		
-ONTIE:0003509	ORF9 (Porcine circovirus 2)	owl:Class		
-ONTIE:0003510	pectate lyase (Bacillus subtilis)	owl:Class		
-ONTIE:0003511	triadin (Homo sapiens)	owl:Class		
-ONTIE:0003512	melanoma associated antigen (Homo sapiens)	owl:Class		
-ONTIE:0003513	Acetyl-coenzyme A synthetase ACSM6 (Homo sapiens)	owl:Class		
-ONTIE:0003514	membrane glycoprotein UL40 (Human betaherpesvirus 5)	owl:Class		
-ONTIE:0003515	retinoid isomerohydrolase isoform X1 (Bos taurus)	owl:Class		
-ONTIE:0003516	non-structural protein 1 (NS1) (Zika virus)	owl:Class		
-ONTIE:0003517	urotensin II (Neogobius melanostomus)	owl:Class		
-ONTIE:0003518	large hepatitis delta antigen (Hepatitis delta virus)	owl:Class		
-ONTIE:0003519	envelope glycoprotein (Crimean-Congo hemorrhagic fever orthonairovirus)	owl:Class		
-ONTIE:0003520	non-structural V protein (Avian avulavirus 1)	owl:Class		
-ONTIE:0003521	alcohol dehydrogenase (Homo sapiens)	owl:Class		
-ONTIE:0003522	arylphorin (Galleria mellonella)	owl:Class		
-ONTIE:0003523	endoglucanase (Clostridium beijerinckii)	owl:Class		
-ONTIE:0003524	adenosine 5',5''',P1,P4-tetraphosphate receptor (Mus musculus)	owl:Class		
-ONTIE:0003525	follitropin subunit beta (Homo sapiens)	owl:Class		
-ONTIE:0003526	Ov-ASP-1 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003527	Ov-CHI-1 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003528	Ov-RBP-1 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003529	Ov-ALT-1 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003530	Ov-B20.16 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003531	Fibrinogen gamma chain (Homo sapiens)	owl:Class		
-ONTIE:0003532	FMRFamide precursor (Macrocallista nimbosa)	owl:Class		
-ONTIE:0003533	ferric reductase (Escherichia coli)	owl:Class		
-ONTIE:0003534	GNAT family N-acetyltransferase (Yersinia enterocolitica)	owl:Class		
-ONTIE:0003535	apolipoprotein E (Homo sapiens)	owl:Class		
-ONTIE:0003536	biglycan (Homo sapiens)	owl:Class		
-ONTIE:0003537	Ov23 (Onchocerca volvulus)	owl:Class		
-ONTIE:0003538	Sec c 1 (Secale cereale)	owl:Class		
-ONTIE:0003539	C-type lectin like protein (African swine fever virus)	owl:Class		
-ONTIE:0003540	permease (Leptospira interrogans)	owl:Class		
-ONTIE:0003541	Pn14TS (Streptococcus pneumoniae)	owl:Class		
-ONTIE:0003542	tissue transglutaminase (Homo sapiens)	owl:Class		
-ONTIE:0003543	beta-conglycinin alpha subunit (Glycine max)	owl:Class		
-ONTIE:0003544	tropomyosin (Crassostrea gigas)	owl:Class		
-ONTIE:0003545	nuclear receptor ROR-gamma isoform X1 (Homo sapiens)	owl:Class		
-ONTIE:0003546	mitochondrial import receptor Tom22 variant (Homo sapiens)	owl:Class		
-ONTIE:0003547	env protein (Homo sapiens)	owl:Class		
-ONTIE:0003548	MMP24 protein (Homo sapiens)	owl:Class		
-ONTIE:0003549	hCG1653259 (Homo sapiens)	owl:Class		
-ONTIE:0003550	arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2 (Homo sapiens)	owl:Class		
-ONTIE:0003551	cadherin-19 (Homo sapiens)	owl:Class		
-ONTIE:0003552	hCG2038477 (Homo sapiens)	owl:Class		
-ONTIE:0003553	cell division cycle protein 20 homolog B (Homo sapiens)	owl:Class		
-ONTIE:0003554	ephrin type-A receptor 3 (Homo sapiens)	owl:Class		
-ONTIE:0003555	basic helix-loop-helix domain-containing protein USF3 (Homo sapiens)	owl:Class		
-ONTIE:0003556	hCG1980844 (Homo sapiens)	owl:Class		
-ONTIE:0003557	selenoprotein N (Homo sapiens)	owl:Class		
-ONTIE:0003558	reverse transcriptase homolog - human retrotransposon L1 (Homo sapiens)	owl:Class		
-ONTIE:0003559	dermal papilla derived protein 6 (Homo sapiens)	owl:Class		
-ONTIE:0003560	2'-5'-oligoadenylate synthase 2 (Homo sapiens)	owl:Class		
-ONTIE:0003561	butyrophilin subfamily 2 member A2 isoform a (Homo sapiens)	owl:Class		
-ONTIE:0003562	protocadherin Fat 3 (Homo sapiens)	owl:Class		
-ONTIE:0003563	zinc finger protein 638 isoform X5 (Homo sapiens)	owl:Class		
-ONTIE:0003564	Transthyretin (Homo sapiens)	owl:Class		
-ONTIE:0003565	lipoxygenase homology domain-containing protein 1 (Homo sapiens)	owl:Class		
-ONTIE:0003566	fusion glycoprotein (Bovine orthopneumovirus)	owl:Class		
-ONTIE:0003567	orexin (Homo sapiens)	owl:Class		
-ONTIE:0003568	large S protein (Hepatitis B virus)	owl:Class		
-ONTIE:0003569	pilin (Escherichia coli)	owl:Class		
-ONTIE:0003570	S100 calcium binding protein B (Homo sapiens)	owl:Class		
-ONTIE:0003571	Uncharacterized protein (Onchocerca volvulus)	owl:Class		
-ONTIE:0003572	matrix protein (Avian avulavirus 1)	owl:Class		
-ONTIE:0003573	VlsE (Borreliella afzelii)	owl:Class		
-ONTIE:0003574	Talin 1 (Homo sapiens)	owl:Class		
-ONTIE:0003575	platelet derived growth factor receptor alpha (Homo sapiens)	owl:Class		
-ONTIE:0003576	dual specificity protein phosphatase 3 (Homo sapiens)	owl:Class		
-ONTIE:0003577	Serine/threonine-protein kinase STK11 (Homo sapiens)	owl:Class		
-ONTIE:0003578	Cadherin EGF LAG seven-pass G-type receptor 1 (Homo sapiens)	owl:Class		
-ONTIE:0003579	odorant response abnormal 4 (Homo sapiens)	owl:Class		
-ONTIE:0003580	Tyrosine-protein kinase ABL2 (Homo sapiens)	owl:Class		
-ONTIE:0003581	Collagen alpha-1(XVI) chain (Homo sapiens)	owl:Class		
-ONTIE:0003582	guanylate cyclase soluble subunit alpha-3 (Homo sapiens)	owl:Class		
-ONTIE:0003583	dual specificity mitogen-activated protein kinase kinase 4 (Homo sapiens)	owl:Class		
-ONTIE:0003584	Putative methyltransferase NSUN3 (Homo sapiens)	owl:Class		
-ONTIE:0003585	Putative glycosyltransferase ALG1-like (Homo sapiens)	owl:Class		
-ONTIE:0003586	phosphomannomutase 2 (Homo sapiens)	owl:Class		
-ONTIE:0003587	Protein argonaute-2 (Homo sapiens)	owl:Class		
-ONTIE:0003588	meningioma-expressed antigen 5s (Homo sapiens)	owl:Class		
-ONTIE:0003589	FtsJ-like protein 1 (Homo sapiens)	owl:Class		
-ONTIE:0003590	Growth arrest-specific protein 6 (Homo sapiens)	owl:Class		
-ONTIE:0003591	HEAT repeat-containing protein 2 (Homo sapiens)	owl:Class		
-ONTIE:0003592	synaptojanin-2 (Homo sapiens)	owl:Class		
-ONTIE:0003593	sodium channel, nonvoltage-gated 1 (Homo sapiens)	owl:Class		
-ONTIE:0003594	deoxyribonuclease I-like 1 (Homo sapiens)	owl:Class		
-ONTIE:0003595	sec24D protein (Homo sapiens)	owl:Class		
-ONTIE:0003596	THEM6 (Homo sapiens)	owl:Class		
-ONTIE:0003597	MYCBP2 (Homo sapiens)	owl:Class		
-ONTIE:0003598	protein farnesyltransferase subunit beta (Homo sapiens)	owl:Class		
-ONTIE:0003599	Rb-associated protein (Homo sapiens)	owl:Class		
-ONTIE:0003600	splicing factor 3B (Homo sapiens)	owl:Class		
-ONTIE:0003601	GTPase NRas (Homo sapiens)	owl:Class		
-ONTIE:0003602	FAST kinase domain-containing protein 2 (Homo sapiens)	owl:Class		
-ONTIE:0003603	proteasomal ubiquitin receptor ADRM1 (Homo sapiens)	owl:Class		
-ONTIE:0003604	angiotensin-converting enzyme isoform 1 (Homo sapiens)	owl:Class		
-ONTIE:0003605	Chromodomain-helicase-DNA-binding protein 1-like (Homo sapiens)	owl:Class		
-ONTIE:0003606	Splicing regulatory glutamine/lysine-rich protein 1 (Homo sapiens)	owl:Class		
-ONTIE:0003607	Receptor tyrosine protein kinase erbB-2 (Homo sapiens)	owl:Class		
-ONTIE:0003608	adhesion G protein coupled receptor D1 (Homo sapiens)	owl:Class		
-ONTIE:0003609	Lysine tRNA ligase (Homo sapiens)	owl:Class		
-ONTIE:0003610	Quinolinate phosphoribosyltransferase (Homo sapiens)	owl:Class		
-ONTIE:0003611	protein tyrosine sulfotransferase 1 (Homo sapiens)	owl:Class		
-ONTIE:0003612	periodic tryptophan protein 2 homolog (Homo sapiens)	owl:Class		
+ONTIE:0003455	Ov-ASP-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003456	Ov-CHI-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003457	Ov-RBP-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003458	Ov-ALT-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003459	Ov-B20.16 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003460	Fibrinogen gamma chain (Homo sapiens)	owl:Class		
+ONTIE:0003461	FMRFamide precursor (Macrocallista nimbosa)	owl:Class		
+ONTIE:0003462	ferric reductase (Escherichia coli)	owl:Class		
+ONTIE:0003463	GNAT family N-acetyltransferase (Yersinia enterocolitica)	owl:Class		
+ONTIE:0003464	apolipoprotein E (Homo sapiens)	owl:Class		
+ONTIE:0003465	biglycan (Homo sapiens)	owl:Class		
+ONTIE:0003466	Ov23 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003467	Sec c 1 (Secale cereale)	owl:Class		
+ONTIE:0003468	C-type lectin like protein (African swine fever virus)	owl:Class		
+ONTIE:0003469	permease (Leptospira interrogans)	owl:Class		
+ONTIE:0003470	Pn14TS (Streptococcus pneumoniae)	owl:Class		
+ONTIE:0003471	tissue transglutaminase (Homo sapiens)	owl:Class		
+ONTIE:0003472	beta-conglycinin alpha subunit (Glycine max)	owl:Class		
+ONTIE:0003473	tropomyosin (Crassostrea gigas)	owl:Class		
+ONTIE:0003474	nuclear receptor ROR-gamma isoform X1 (Homo sapiens)	owl:Class		
+ONTIE:0003475	mitochondrial import receptor Tom22 variant (Homo sapiens)	owl:Class		
+ONTIE:0003476	env protein (Homo sapiens)	owl:Class		
+ONTIE:0003477	MMP24 protein (Homo sapiens)	owl:Class		
+ONTIE:0003478	hCG1653259 (Homo sapiens)	owl:Class		
+ONTIE:0003479	arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003480	cadherin-19 (Homo sapiens)	owl:Class		
+ONTIE:0003481	hCG2038477 (Homo sapiens)	owl:Class		
+ONTIE:0003482	cell division cycle protein 20 homolog B (Homo sapiens)	owl:Class		
+ONTIE:0003483	ephrin type-A receptor 3 (Homo sapiens)	owl:Class		
+ONTIE:0003484	basic helix-loop-helix domain-containing protein USF3 (Homo sapiens)	owl:Class		
+ONTIE:0003485	hCG1980844 (Homo sapiens)	owl:Class		
+ONTIE:0003486	selenoprotein N (Homo sapiens)	owl:Class		
+ONTIE:0003487	reverse transcriptase homolog - human retrotransposon L1 (Homo sapiens)	owl:Class		
+ONTIE:0003488	dermal papilla derived protein 6 (Homo sapiens)	owl:Class		
+ONTIE:0003489	2'-5'-oligoadenylate synthase 2 (Homo sapiens)	owl:Class		
+ONTIE:0003490	butyrophilin subfamily 2 member A2 isoform a (Homo sapiens)	owl:Class		
+ONTIE:0003491	protocadherin Fat 3 (Homo sapiens)	owl:Class		
+ONTIE:0003492	zinc finger protein 638 isoform X5 (Homo sapiens)	owl:Class		
+ONTIE:0003493	Transthyretin (Homo sapiens)	owl:Class		
+ONTIE:0003494	lipoxygenase homology domain-containing protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003495	fusion glycoprotein (Bovine orthopneumovirus)	owl:Class		
+ONTIE:0003496	orexin (Homo sapiens)	owl:Class		
+ONTIE:0003497	large S protein (Hepatitis B virus)	owl:Class		
+ONTIE:0003498	pilin (Escherichia coli)	owl:Class		
+ONTIE:0003499	S100 calcium binding protein B (Homo sapiens)	owl:Class		
+ONTIE:0003500	Uncharacterized protein (Onchocerca volvulus)	owl:Class		
+ONTIE:0003501	matrix protein (Avian avulavirus 1)	owl:Class		
+ONTIE:0003502	VlsE (Borreliella afzelii)	owl:Class		
+ONTIE:0003503	Talin 1 (Homo sapiens)	owl:Class		
+ONTIE:0003504	platelet derived growth factor receptor alpha (Homo sapiens)	owl:Class		
+ONTIE:0003505	dual specificity protein phosphatase 3 (Homo sapiens)	owl:Class		
+ONTIE:0003506	Serine/threonine-protein kinase STK11 (Homo sapiens)	owl:Class		
+ONTIE:0003507	Cadherin EGF LAG seven-pass G-type receptor 1 (Homo sapiens)	owl:Class		
+ONTIE:0003508	odorant response abnormal 4 (Homo sapiens)	owl:Class		
+ONTIE:0003509	Tyrosine-protein kinase ABL2 (Homo sapiens)	owl:Class		
+ONTIE:0003510	Collagen alpha-1(XVI) chain (Homo sapiens)	owl:Class		
+ONTIE:0003511	guanylate cyclase soluble subunit alpha-3 (Homo sapiens)	owl:Class		
+ONTIE:0003512	dual specificity mitogen-activated protein kinase kinase 4 (Homo sapiens)	owl:Class		
+ONTIE:0003513	Putative methyltransferase NSUN3 (Homo sapiens)	owl:Class		
+ONTIE:0003514	Putative glycosyltransferase ALG1-like (Homo sapiens)	owl:Class		
+ONTIE:0003515	phosphomannomutase 2 (Homo sapiens)	owl:Class		
+ONTIE:0003516	Protein argonaute-2 (Homo sapiens)	owl:Class		
+ONTIE:0003517	meningioma-expressed antigen 5s (Homo sapiens)	owl:Class		
+ONTIE:0003518	FtsJ-like protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003519	Growth arrest-specific protein 6 (Homo sapiens)	owl:Class		
+ONTIE:0003520	HEAT repeat-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003521	synaptojanin-2 (Homo sapiens)	owl:Class		
+ONTIE:0003522	sodium channel, nonvoltage-gated 1 (Homo sapiens)	owl:Class		
+ONTIE:0003523	deoxyribonuclease I-like 1 (Homo sapiens)	owl:Class		
+ONTIE:0003524	sec24D protein (Homo sapiens)	owl:Class		
+ONTIE:0003525	THEM6 (Homo sapiens)	owl:Class		
+ONTIE:0003526	MYCBP2 (Homo sapiens)	owl:Class		
+ONTIE:0003527	protein farnesyltransferase subunit beta (Homo sapiens)	owl:Class		
+ONTIE:0003528	Rb-associated protein (Homo sapiens)	owl:Class		
+ONTIE:0003529	splicing factor 3B (Homo sapiens)	owl:Class		
+ONTIE:0003530	GTPase NRas (Homo sapiens)	owl:Class		
+ONTIE:0003531	FAST kinase domain-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003532	proteasomal ubiquitin receptor ADRM1 (Homo sapiens)	owl:Class		
+ONTIE:0003533	angiotensin-converting enzyme isoform 1 (Homo sapiens)	owl:Class		
+ONTIE:0003534	Chromodomain-helicase-DNA-binding protein 1-like (Homo sapiens)	owl:Class		
+ONTIE:0003535	Splicing regulatory glutamine/lysine-rich protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003536	Receptor tyrosine protein kinase erbB-2 (Homo sapiens)	owl:Class		
+ONTIE:0003537	adhesion G protein coupled receptor D1 (Homo sapiens)	owl:Class		
+ONTIE:0003538	Lysine tRNA ligase (Homo sapiens)	owl:Class		
+ONTIE:0003539	Quinolinate phosphoribosyltransferase (Homo sapiens)	owl:Class		
+ONTIE:0003540	protein tyrosine sulfotransferase 1 (Homo sapiens)	owl:Class		
+ONTIE:0003541	periodic tryptophan protein 2 homolog (Homo sapiens)	owl:Class		

--- a/ontology/index.tsv
+++ b/ontology/index.tsv
@@ -3456,3 +3456,196 @@ ONTIE:0003416	arylphorin (Galleria mellonella)	owl:Class
 ONTIE:0003417	endoglucanase (Clostridium beijerinckii)	owl:Class		
 ONTIE:0003418	adenosine 5',5''',P1,P4-tetraphosphate receptor (Mus musculus)	owl:Class		
 ONTIE:0003419	follitropin subunit beta (Homo sapiens)	owl:Class		
+ONTIE:0003420	model of human disease	owl:ObjectProperty		
+ONTIE:0003421	transplant-related disease and allo-reactivity	owl:Class		
+ONTIE:0003422	rejection of transplanted organs and tissues	owl:Class		
+ONTIE:0003423	healthy	owl:Class		
+ONTIE:0003424	asymptomatic infection	owl:Class		
+ONTIE:0003425	asymptomatic HIV infection	owl:Class		
+ONTIE:0003426	human T-lymphotropic virus 1 carrier	owl:Class		
+ONTIE:0003427	animal model of disease	owl:Class		
+ONTIE:0003428	animal model of autoimmune disease	owl:Class		
+ONTIE:0003429	experimental arthritis	owl:Class		
+ONTIE:0003430	collagen-induced arthritis (CIA)	owl:Class		
+ONTIE:0003431	adjuvant-induced arthritis (AIA)	owl:Class		
+ONTIE:0003432	experimental autoimmune ovarian disease (oophoritis)	owl:Class		
+ONTIE:0003433	experimental autoimmune uveitis (EAU)	owl:Class		
+ONTIE:0003434	experimental autoimmune neuritis (EAN)	owl:Class		
+ONTIE:0003435	experimental autoimmune encephalomyelitis (EAE)	owl:Class		
+ONTIE:0003436	experimental autoimmune myasthenia gravis (EAMG)	owl:Class		
+ONTIE:0003437	experimental autoimmune glomerulonephritis (EAG)	owl:Class		
+ONTIE:0003438	experimental Graves' disease	owl:Class		
+ONTIE:0003439	experimental autoimmune myocarditis (EAM)	owl:Class		
+ONTIE:0003440	experimental immune-mediated cholangiopathy	owl:Class		
+ONTIE:0003441	experimental autoimmune sensorineural hearing loss	owl:Class		
+ONTIE:0003442	experimental autoimmune thyroiditis (EAT)	owl:Class		
+ONTIE:0003443	experimental autoimmune prostatitis	owl:Class		
+ONTIE:0003444	habitual abortion	owl:Class	
+ONTIE:0003445	Enterovirus D68 Kunming	owl:Class		
+ONTIE:0003446	Enterovirus D68 Fermon	owl:Class		
+ONTIE:0003447	Babesia bovis T3Bo	owl:Class		
+ONTIE:0003448	Leishmania amazonensis MHOM/BR/73/M2269	owl:Class		
+ONTIE:0003449	Leishmania braziliensis MHOM/BR/94/M2903	owl:Class		
+ONTIE:0003450	Yellow fever virus CNYF01/2016	owl:Class		
+ONTIE:0003451	Fowlpox virus FP9	owl:Class		
+ONTIE:0003452	Salmonella enterica subsp. enterica serovar Typhi str. Quailes	owl:Class		
+ONTIE:0003453	Salmonella enterica subsp. enterica serovar Paratyphi A str. NVGH308	owl:Class		
+ONTIE:0003454	Enterobacteria phage PRD1	owl:Class		
+ONTIE:0003455	band 3 anion transport protein (Mus musculus)	owl:Class		
+ONTIE:0003456	ubiquitin-associated domain-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003457	CD74/ROS (Homo sapiens)	owl:Class		
+ONTIE:0003458	cyclin-dependent kinase 3 (Homo sapiens)	owl:Class		
+ONTIE:0003459	Uncharacterized protein KIAA0754 (Homo sapiens)	owl:Class		
+ONTIE:0003460	Major Peanut Allergen Ara H 6 (Arachis hypogaea)	owl:Class		
+ONTIE:0003461	epsilon toxin (Clostridium perfringens)	owl:Class		
+ONTIE:0003462	DNA processivity factor (Human betaherpesvirus 5)	owl:Class		
+ONTIE:0003463	synuclein (Homo sapiens)	owl:Class		
+ONTIE:0003464	phospholipase A2 inhibitor gamma (Sinonatrix annularis)	owl:Class		
+ONTIE:0003465	phospholipase A2 inhibitor gamma (Macropisthodon rudis)	owl:Class		
+ONTIE:0003466	phospholipase A2 inhibitor gamma (Elaphe carinata)	owl:Class		
+ONTIE:0003467	phospholipase A2 inhibitor gamma (Ptyas dhumnades)	owl:Class		
+ONTIE:0003468	phospholipase A2 inhibitor gamma (Elaphe taeniura)	owl:Class		
+ONTIE:0003469	phospholipase A2 inhibitor gamma (Lycodon rufozonatus)	owl:Class		
+ONTIE:0003470	phospholipase A2 inhibitor gamma (Oocatochus rufodorsatus)	owl:Class		
+ONTIE:0003471	carbonate dehydratase (Mycobacterium tuberculosis)	owl:Class		
+ONTIE:0003472	glycoprotein G (Human alphaherpesvirus 1)	owl:Class		
+ONTIE:0003473	glycoprotein G (Human alphaherpesvirus 2)	owl:Class		
+ONTIE:0003474	holin (Salmonella enterica)	owl:Class		
+ONTIE:0003475	DNA polymerase III subunit gamma/tau (Salmonella enterica)	owl:Class		
+ONTIE:0003476	formate transporter FocA (Salmonella enterica)	owl:Class		
+ONTIE:0003477	phage baseplate protein (Salmonella enterica)	owl:Class		
+ONTIE:0003478	RNA helicase (Salmonella enterica)	owl:Class		
+ONTIE:0003479	valine tRNA ligase (Salmonella enterica)	owl:Class		
+ONTIE:0003480	hypothetical protein (Salmonella enterica)	owl:Class		
+ONTIE:0003481	PTS system mannitol-specific transporter subunit IIA (Salmonella enterica)	owl:Class		
+ONTIE:0003482	Zn-dependent protease (Salmonella enterica)	owl:Class		
+ONTIE:0003483	serine/threonine protein kinase (Salmonella enterica)	owl:Class		
+ONTIE:0003484	chloramphenicol/florfenicol efflux MFS transporter FloR (Salmonella enterica)	owl:Class		
+ONTIE:0003485	AraC family transcriptional regulator (Salmonella enterica)	owl:Class		
+ONTIE:0003486	glucosyltransferase (Salmonella enterica)	owl:Class		
+ONTIE:0003487	protein RarD (Salmonella enterica)	owl:Class		
+ONTIE:0003488	von Willebrand factor-cleaving protease precursor (Homo sapiens)	owl:Class		
+ONTIE:0003489	nucleocapsid protein (Canine morbillivirus)	owl:Class		
+ONTIE:0003490	Protocadherin-24 Ec1-3 (Mus musculus)	owl:Class		
+ONTIE:0003491	collagen alpha-3(VI) chain (Equus przewalskii)	owl:Class		
+ONTIE:0003492	Collagen alpha-1(VII) chain (Mus musculus)	owl:Class		
+ONTIE:0003493	MF6p ortholog protein (Paragonimus westermani)	owl:Class		
+ONTIE:0003494	ATP synthase subunit beta (Plasmodium berghei)	owl:Class		
+ONTIE:0003495	ubiquitin carboxyl-terminal hydrolase 47 (Mus musculus)	owl:Class		
+ONTIE:0003496	transcription factor 4 (Mus musculus)	owl:Class		
+ONTIE:0003497	anaphase-promoting complex (Mus musculus)	owl:Class		
+ONTIE:0003498	solute carrier family 2, facilitated glucose transporter member 7 (Mus musculus)	owl:Class		
+ONTIE:0003499	transmembrane protein vezatin (Homo sapiens)	owl:Class		
+ONTIE:0003500	Werner syndrome ATP-dependent helicase (Homo sapiens)	owl:Class		
+ONTIE:0003501	conserved Plasmodium protein (Plasmodium berghei)	owl:Class		
+ONTIE:0003502	hypothetical protein, conserved (Leishmania donovani)	owl:Class		
+ONTIE:0003503	potassium-transporting ATPase alpha chain 1 (Oryctolagus cuniculus)	owl:Class		
+ONTIE:0003504	NACHT and WD repeat domain-containing protein 2 (Rattus norvegicus)	owl:Class		
+ONTIE:0003505	collagen alpha-3(VI) chain (Mus musculus)	owl:Class		
+ONTIE:0003506	troponin T cardiac (Carassius auratus)	owl:Class		
+ONTIE:0003507	troponin T cardiac (Melospiza melodia)	owl:Class		
+ONTIE:0003508	Major surface glycoprotein G (Human respiratory syncytial virus A)	owl:Class		
+ONTIE:0003509	ORF9 (Porcine circovirus 2)	owl:Class		
+ONTIE:0003510	pectate lyase (Bacillus subtilis)	owl:Class		
+ONTIE:0003511	triadin (Homo sapiens)	owl:Class		
+ONTIE:0003512	melanoma associated antigen (Homo sapiens)	owl:Class		
+ONTIE:0003513	Acetyl-coenzyme A synthetase ACSM6 (Homo sapiens)	owl:Class		
+ONTIE:0003514	membrane glycoprotein UL40 (Human betaherpesvirus 5)	owl:Class		
+ONTIE:0003515	retinoid isomerohydrolase isoform X1 (Bos taurus)	owl:Class		
+ONTIE:0003516	non-structural protein 1 (NS1) (Zika virus)	owl:Class		
+ONTIE:0003517	urotensin II (Neogobius melanostomus)	owl:Class		
+ONTIE:0003518	large hepatitis delta antigen (Hepatitis delta virus)	owl:Class		
+ONTIE:0003519	envelope glycoprotein (Crimean-Congo hemorrhagic fever orthonairovirus)	owl:Class		
+ONTIE:0003520	non-structural V protein (Avian avulavirus 1)	owl:Class		
+ONTIE:0003521	alcohol dehydrogenase (Homo sapiens)	owl:Class		
+ONTIE:0003522	arylphorin (Galleria mellonella)	owl:Class		
+ONTIE:0003523	endoglucanase (Clostridium beijerinckii)	owl:Class		
+ONTIE:0003524	adenosine 5',5''',P1,P4-tetraphosphate receptor (Mus musculus)	owl:Class		
+ONTIE:0003525	follitropin subunit beta (Homo sapiens)	owl:Class		
+ONTIE:0003526	Ov-ASP-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003527	Ov-CHI-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003528	Ov-RBP-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003529	Ov-ALT-1 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003530	Ov-B20.16 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003531	Fibrinogen gamma chain (Homo sapiens)	owl:Class		
+ONTIE:0003532	FMRFamide precursor (Macrocallista nimbosa)	owl:Class		
+ONTIE:0003533	ferric reductase (Escherichia coli)	owl:Class		
+ONTIE:0003534	GNAT family N-acetyltransferase (Yersinia enterocolitica)	owl:Class		
+ONTIE:0003535	apolipoprotein E (Homo sapiens)	owl:Class		
+ONTIE:0003536	biglycan (Homo sapiens)	owl:Class		
+ONTIE:0003537	Ov23 (Onchocerca volvulus)	owl:Class		
+ONTIE:0003538	Sec c 1 (Secale cereale)	owl:Class		
+ONTIE:0003539	C-type lectin like protein (African swine fever virus)	owl:Class		
+ONTIE:0003540	permease (Leptospira interrogans)	owl:Class		
+ONTIE:0003541	Pn14TS (Streptococcus pneumoniae)	owl:Class		
+ONTIE:0003542	tissue transglutaminase (Homo sapiens)	owl:Class		
+ONTIE:0003543	beta-conglycinin alpha subunit (Glycine max)	owl:Class		
+ONTIE:0003544	tropomyosin (Crassostrea gigas)	owl:Class		
+ONTIE:0003545	nuclear receptor ROR-gamma isoform X1 (Homo sapiens)	owl:Class		
+ONTIE:0003546	mitochondrial import receptor Tom22 variant (Homo sapiens)	owl:Class		
+ONTIE:0003547	env protein (Homo sapiens)	owl:Class		
+ONTIE:0003548	MMP24 protein (Homo sapiens)	owl:Class		
+ONTIE:0003549	hCG1653259 (Homo sapiens)	owl:Class		
+ONTIE:0003550	arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003551	cadherin-19 (Homo sapiens)	owl:Class		
+ONTIE:0003552	hCG2038477 (Homo sapiens)	owl:Class		
+ONTIE:0003553	cell division cycle protein 20 homolog B (Homo sapiens)	owl:Class		
+ONTIE:0003554	ephrin type-A receptor 3 (Homo sapiens)	owl:Class		
+ONTIE:0003555	basic helix-loop-helix domain-containing protein USF3 (Homo sapiens)	owl:Class		
+ONTIE:0003556	hCG1980844 (Homo sapiens)	owl:Class		
+ONTIE:0003557	selenoprotein N (Homo sapiens)	owl:Class		
+ONTIE:0003558	reverse transcriptase homolog - human retrotransposon L1 (Homo sapiens)	owl:Class		
+ONTIE:0003559	dermal papilla derived protein 6 (Homo sapiens)	owl:Class		
+ONTIE:0003560	2'-5'-oligoadenylate synthase 2 (Homo sapiens)	owl:Class		
+ONTIE:0003561	butyrophilin subfamily 2 member A2 isoform a (Homo sapiens)	owl:Class		
+ONTIE:0003562	protocadherin Fat 3 (Homo sapiens)	owl:Class		
+ONTIE:0003563	zinc finger protein 638 isoform X5 (Homo sapiens)	owl:Class		
+ONTIE:0003564	Transthyretin (Homo sapiens)	owl:Class		
+ONTIE:0003565	lipoxygenase homology domain-containing protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003566	fusion glycoprotein (Bovine orthopneumovirus)	owl:Class		
+ONTIE:0003567	orexin (Homo sapiens)	owl:Class		
+ONTIE:0003568	large S protein (Hepatitis B virus)	owl:Class		
+ONTIE:0003569	pilin (Escherichia coli)	owl:Class		
+ONTIE:0003570	S100 calcium binding protein B (Homo sapiens)	owl:Class		
+ONTIE:0003571	Uncharacterized protein (Onchocerca volvulus)	owl:Class		
+ONTIE:0003572	matrix protein (Avian avulavirus 1)	owl:Class		
+ONTIE:0003573	VlsE (Borreliella afzelii)	owl:Class		
+ONTIE:0003574	Talin 1 (Homo sapiens)	owl:Class		
+ONTIE:0003575	platelet derived growth factor receptor alpha (Homo sapiens)	owl:Class		
+ONTIE:0003576	dual specificity protein phosphatase 3 (Homo sapiens)	owl:Class		
+ONTIE:0003577	Serine/threonine-protein kinase STK11 (Homo sapiens)	owl:Class		
+ONTIE:0003578	Cadherin EGF LAG seven-pass G-type receptor 1 (Homo sapiens)	owl:Class		
+ONTIE:0003579	odorant response abnormal 4 (Homo sapiens)	owl:Class		
+ONTIE:0003580	Tyrosine-protein kinase ABL2 (Homo sapiens)	owl:Class		
+ONTIE:0003581	Collagen alpha-1(XVI) chain (Homo sapiens)	owl:Class		
+ONTIE:0003582	guanylate cyclase soluble subunit alpha-3 (Homo sapiens)	owl:Class		
+ONTIE:0003583	dual specificity mitogen-activated protein kinase kinase 4 (Homo sapiens)	owl:Class		
+ONTIE:0003584	Putative methyltransferase NSUN3 (Homo sapiens)	owl:Class		
+ONTIE:0003585	Putative glycosyltransferase ALG1-like (Homo sapiens)	owl:Class		
+ONTIE:0003586	phosphomannomutase 2 (Homo sapiens)	owl:Class		
+ONTIE:0003587	Protein argonaute-2 (Homo sapiens)	owl:Class		
+ONTIE:0003588	meningioma-expressed antigen 5s (Homo sapiens)	owl:Class		
+ONTIE:0003589	FtsJ-like protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003590	Growth arrest-specific protein 6 (Homo sapiens)	owl:Class		
+ONTIE:0003591	HEAT repeat-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003592	synaptojanin-2 (Homo sapiens)	owl:Class		
+ONTIE:0003593	sodium channel, nonvoltage-gated 1 (Homo sapiens)	owl:Class		
+ONTIE:0003594	deoxyribonuclease I-like 1 (Homo sapiens)	owl:Class		
+ONTIE:0003595	sec24D protein (Homo sapiens)	owl:Class		
+ONTIE:0003596	THEM6 (Homo sapiens)	owl:Class		
+ONTIE:0003597	MYCBP2 (Homo sapiens)	owl:Class		
+ONTIE:0003598	protein farnesyltransferase subunit beta (Homo sapiens)	owl:Class		
+ONTIE:0003599	Rb-associated protein (Homo sapiens)	owl:Class		
+ONTIE:0003600	splicing factor 3B (Homo sapiens)	owl:Class		
+ONTIE:0003601	GTPase NRas (Homo sapiens)	owl:Class		
+ONTIE:0003602	FAST kinase domain-containing protein 2 (Homo sapiens)	owl:Class		
+ONTIE:0003603	proteasomal ubiquitin receptor ADRM1 (Homo sapiens)	owl:Class		
+ONTIE:0003604	angiotensin-converting enzyme isoform 1 (Homo sapiens)	owl:Class		
+ONTIE:0003605	Chromodomain-helicase-DNA-binding protein 1-like (Homo sapiens)	owl:Class		
+ONTIE:0003606	Splicing regulatory glutamine/lysine-rich protein 1 (Homo sapiens)	owl:Class		
+ONTIE:0003607	Receptor tyrosine protein kinase erbB-2 (Homo sapiens)	owl:Class		
+ONTIE:0003608	adhesion G protein coupled receptor D1 (Homo sapiens)	owl:Class		
+ONTIE:0003609	Lysine tRNA ligase (Homo sapiens)	owl:Class		
+ONTIE:0003610	Quinolinate phosphoribosyltransferase (Homo sapiens)	owl:Class		
+ONTIE:0003611	protein tyrosine sulfotransferase 1 (Homo sapiens)	owl:Class		
+ONTIE:0003612	periodic tryptophan protein 2 homolog (Homo sapiens)	owl:Class		

--- a/ontology/ontie.kn
+++ b/ontology/ontie.kn
@@ -22234,3 +22234,906 @@ definition: A disease characterized by 3 consecutive pregnancy losses prior to 2
 definition source: PMID:19609401
 alternative term: recurrent miscarriage
 alternative term: recurrent pregnancy loss
+
+: ONTIE:0003445
+apply template: taxon class
+ label: Enterovirus D68 Kunming
+ parent taxon: Enterovirus D68
+alternative term: KM
+alternative term: RVL_KM201703
+rank: subspecies
+
+: ONTIE:0003446
+apply template: taxon class
+ label: Enterovirus D68 Fermon
+ parent taxon: Enterovirus D68
+rank: subspecies
+
+: ONTIE:0003447
+apply template: taxon class
+ label: Babesia bovis T3Bo
+ parent taxon: Babesia bovis
+alternative term: USA T3Bo
+alternative term: T3Bo
+rank: subspecies
+
+: ONTIE:0003448
+apply template: taxon class
+ label: Leishmania amazonensis MHOM/BR/73/M2269
+ parent taxon: Leishmania amazonensis
+alternative term: M2269
+rank: subspecies
+
+: ONTIE:0003449
+apply template: taxon class
+ label: Leishmania braziliensis MHOM/BR/94/M2903
+ parent taxon: Leishmania braziliensis
+alternative term: M2903
+rank: subspecies
+
+: ONTIE:0003450
+apply template: taxon class
+ label: Yellow fever virus CNYF01/2016
+ parent taxon: Yellow fever virus
+alternative term: CNYF01/2016
+alternative term: China
+rank: subspecies
+
+: ONTIE:0003451
+apply template: taxon class
+ label: Fowlpox virus FP9
+ parent taxon: Fowlpox virus
+alternative term: FP9
+rank: subspecies
+
+: ONTIE:0003452
+apply template: taxon class
+ label: Salmonella enterica subsp. enterica serovar Typhi str. Quailes
+ parent taxon: Salmonella enterica subsp. enterica serovar Typhi
+alternative term: Quailes
+rank: subspecies
+
+: ONTIE:0003453
+apply template: taxon class
+ label: Salmonella enterica subsp. enterica serovar Paratyphi A str. NVGH308
+ parent taxon: Salmonella enterica subsp. enterica serovar Paratyphi A
+alternative term: NVGH308
+rank: subspecies
+
+: ONTIE:0003454
+apply template: taxon class
+ label: Enterobacteria phage PRD1
+ parent taxon: Pseudomonas virus PRD1
+rank: no rank
+
+: ONTIE:0003455
+apply template: protein class
+ label: band 3 anion transport protein
+ taxon: Mus musculus
+
+: ONTIE:0003456
+apply template: protein class
+ label: ubiquitin-associated domain-containing protein 2
+ taxon: Homo sapiens
+
+: ONTIE:0003457
+apply template: protein class
+ label: CD74/ROS
+ taxon: Homo sapiens
+alternative term: CD74-TRKA
+
+: ONTIE:0003458
+apply template: protein class
+ label: cyclin-dependent kinase 3
+ taxon: Homo sapiens
+
+: ONTIE:0003459
+apply template: protein class
+ label: Uncharacterized protein KIAA0754
+ taxon: Homo sapiens
+
+: ONTIE:0003460
+apply template: protein class
+ label: Major Peanut Allergen Ara H 6
+ taxon: Arachis hypogaea
+alternative term: Conglutin
+
+: ONTIE:0003461
+apply template: protein class
+ label: epsilon toxin
+ taxon: Clostridium perfringens
+alternative term: epsilon-toxin
+
+: ONTIE:0003462
+apply template: protein class
+ label: DNA processivity factor
+ taxon: Human betaherpesvirus 5
+
+: ONTIE:0003463
+apply template: protein class
+ label: synuclein
+ taxon: Homo sapiens
+
+: ONTIE:0003464
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Sinonatrix annularis
+alternative term: PLIg
+
+: ONTIE:0003465
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Macropisthodon rudis
+
+: ONTIE:0003466
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Elaphe carinata
+
+: ONTIE:0003467
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Ptyas dhumnades
+
+: ONTIE:0003468
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Elaphe taeniura
+
+: ONTIE:0003469
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Lycodon rufozonatus
+alternative term: PLIg
+
+: ONTIE:0003470
+apply template: protein class
+ label: phospholipase A2 inhibitor gamma
+ taxon: Oocatochus rufodorsatus
+alternative term: PLIg
+
+: ONTIE:0003471
+apply template: protein class
+ label: carbonate dehydratase
+ taxon: Mycobacterium tuberculosis
+alternative term: carbonite dehydrogynase
+
+: ONTIE:0003472
+apply template: protein class
+ label: glycoprotein G
+ taxon: Human alphaherpesvirus 1
+
+: ONTIE:0003473
+apply template: protein class
+ label: glycoprotein G
+ taxon: Human alphaherpesvirus 2
+
+: ONTIE:0003474
+apply template: protein class
+ label: holin
+ taxon: Salmonella enterica
+
+: ONTIE:0003475
+apply template: protein class
+ label: DNA polymerase III subunit gamma/tau
+ taxon: Salmonella enterica
+
+: ONTIE:0003476
+apply template: protein class
+ label: formate transporter FocA
+ taxon: Salmonella enterica
+
+: ONTIE:0003477
+apply template: protein class
+ label: phage baseplate protein
+ taxon: Salmonella enterica
+
+: ONTIE:0003478
+apply template: protein class
+ label: RNA helicase
+ taxon: Salmonella enterica
+
+: ONTIE:0003479
+apply template: protein class
+ label: valine tRNA ligase
+ taxon: Salmonella enterica
+
+: ONTIE:0003480
+apply template: protein class
+ label: hypothetical protein
+ taxon: Salmonella enterica
+
+: ONTIE:0003481
+apply template: protein class
+ label: PTS system mannitol-specific transporter subunit IIA
+ taxon: Salmonella enterica
+
+: ONTIE:0003482
+apply template: protein class
+ label: Zn-dependent protease
+ taxon: Salmonella enterica
+
+: ONTIE:0003483
+apply template: protein class
+ label: serine/threonine protein kinase
+ taxon: Salmonella enterica
+
+: ONTIE:0003484
+apply template: protein class
+ label: chloramphenicol/florfenicol efflux MFS transporter FloR
+ taxon: Salmonella enterica
+
+: ONTIE:0003485
+apply template: protein class
+ label: AraC family transcriptional regulator
+ taxon: Salmonella enterica
+
+: ONTIE:0003486
+apply template: protein class
+ label: glucosyltransferase
+ taxon: Salmonella enterica
+
+: ONTIE:0003487
+apply template: protein class
+ label: protein RarD
+ taxon: Salmonella enterica
+
+: ONTIE:0003488
+apply template: protein class
+ label: von Willebrand factor-cleaving protease precursor
+ taxon: Homo sapiens
+
+: ONTIE:0003489
+apply template: protein class
+ label: nucleocapsid protein
+ taxon: Canine morbillivirus
+
+: ONTIE:0003490
+apply template: protein class
+ label: Protocadherin-24 Ec1-3
+ taxon: Mus musculus
+
+: ONTIE:0003491
+apply template: protein class
+ label: collagen alpha-3(VI) chain
+ taxon: Equus przewalskii
+
+: ONTIE:0003492
+apply template: protein class
+ label: Collagen alpha-1(VII) chain
+ taxon: Mus musculus
+
+: ONTIE:0003493
+apply template: protein class
+ label: MF6p ortholog protein
+ taxon: Paragonimus westermani
+
+: ONTIE:0003494
+apply template: protein class
+ label: ATP synthase subunit beta
+ taxon: Plasmodium berghei
+
+: ONTIE:0003495
+apply template: protein class
+ label: ubiquitin carboxyl-terminal hydrolase 47
+ taxon: Mus musculus
+
+: ONTIE:0003496
+apply template: protein class
+ label: transcription factor 4
+ taxon: Mus musculus
+
+: ONTIE:0003497
+apply template: protein class
+ label: anaphase-promoting complex
+ taxon: Mus musculus
+
+: ONTIE:0003498
+apply template: protein class
+ label: solute carrier family 2, facilitated glucose transporter member 7
+ taxon: Mus musculus
+
+: ONTIE:0003499
+apply template: protein class
+ label: transmembrane protein vezatin
+ taxon: Homo sapiens
+
+: ONTIE:0003500
+apply template: protein class
+ label: Werner syndrome ATP-dependent helicase
+ taxon: Homo sapiens
+
+: ONTIE:0003501
+apply template: protein class
+ label: conserved Plasmodium protein
+ taxon: Plasmodium berghei
+
+: ONTIE:0003502
+apply template: protein class
+ label: hypothetical protein, conserved
+ taxon: Leishmania donovani
+
+: ONTIE:0003503
+apply template: protein class
+ label: potassium-transporting ATPase alpha chain 1
+ taxon: Oryctolagus cuniculus
+
+: ONTIE:0003504
+apply template: protein class
+ label: NACHT and WD repeat domain-containing protein 2
+ taxon: Rattus norvegicus
+alternative term: Nwd2
+
+: ONTIE:0003505
+apply template: protein class
+ label: collagen alpha-3(VI) chain
+ taxon: Mus musculus
+
+: ONTIE:0003506
+apply template: protein class
+ label: troponin T cardiac
+ taxon: Carassius auratus
+
+: ONTIE:0003507
+apply template: protein class
+ label: troponin T cardiac
+ taxon: Melospiza melodia
+
+: ONTIE:0003508
+apply template: protein class
+ label: Major surface glycoprotein G
+ taxon: Human respiratory syncytial virus A
+
+: ONTIE:0003509
+apply template: protein class
+ label: ORF9
+ taxon: Porcine circovirus 2
+
+: ONTIE:0003510
+apply template: protein class
+ label: pectate lyase
+ taxon: Bacillus subtilis
+
+: ONTIE:0003511
+apply template: protein class
+ label: triadin
+ taxon: Homo sapiens
+
+: ONTIE:0003512
+apply template: protein class
+ label: melanoma associated antigen
+ taxon: Homo sapiens
+
+: ONTIE:0003513
+apply template: protein class
+ label: Acetyl-coenzyme A synthetase ACSM6
+ taxon: Homo sapiens
+alternative term: acetyl coenzyme A
+alternative term: synthetase
+alternative term: ACSM6
+
+: ONTIE:0003514
+apply template: protein class
+ label: membrane glycoprotein UL40
+ taxon: Human betaherpesvirus 5
+alternative term: UL40
+
+: ONTIE:0003515
+apply template: protein class
+ label: retinoid isomerohydrolase isoform X1
+ taxon: Bos taurus
+
+: ONTIE:0003516
+apply template: protein class
+ label: non-structural protein 1 (NS1)
+ taxon: Zika virus
+alternative term: NS1
+
+: ONTIE:0003517
+apply template: protein class
+ label: urotensin II
+ taxon: Neogobius melanostomus
+
+: ONTIE:0003518
+apply template: protein class
+ label: large hepatitis delta antigen
+ taxon: Hepatitis delta virus
+alternative term: L-HDAg
+
+: ONTIE:0003519
+apply template: protein class
+ label: envelope glycoprotein
+ taxon: Crimean-Congo hemorrhagic fever orthonairovirus
+
+: ONTIE:0003520
+apply template: protein class
+ label: non-structural V protein
+ taxon: Avian avulavirus 1
+
+: ONTIE:0003521
+apply template: protein class
+ label: alcohol dehydrogenase
+ taxon: Homo sapiens
+alternative term: ADH
+
+: ONTIE:0003522
+apply template: protein class
+ label: arylphorin
+ taxon: Galleria mellonella
+alternative term: Gal lysin-1
+
+: ONTIE:0003523
+apply template: protein class
+ label: endoglucanase
+ taxon: Clostridium beijerinckii
+
+: ONTIE:0003524
+apply template: protein class
+ label: adenosine 5',5''',P1,P4-tetraphosphate receptor
+ taxon: Mus musculus
+alternative term: Ap4A
+alternative term: adenosine 5',5"',P1,P4-tetraphosphate receptor
+
+: ONTIE:0003525
+apply template: protein class
+ label: follitropin subunit beta
+ taxon: Homo sapiens
+alternative term: follicle-stimulating hormone beta
+alternative term: FSHB
+
+: ONTIE:0003526
+apply template: protein class
+ label: Ov-ASP-1
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003527
+apply template: protein class
+ label: Ov-CHI-1
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003528
+apply template: protein class
+ label: Ov-RBP-1
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003529
+apply template: protein class
+ label: Ov-ALT-1
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003530
+apply template: protein class
+ label: Ov-B20.16
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003531
+apply template: protein class
+ label: Fibrinogen gamma chain
+ taxon: Homo sapiens
+
+: ONTIE:0003532
+apply template: protein class
+ label: FMRFamide precursor
+ taxon: Macrocallista nimbosa
+
+: ONTIE:0003533
+apply template: protein class
+ label: ferric reductase
+ taxon: Escherichia coli
+
+: ONTIE:0003534
+apply template: protein class
+ label: GNAT family N-acetyltransferase
+ taxon: Yersinia enterocolitica
+
+: ONTIE:0003535
+apply template: protein class
+ label: apolipoprotein E
+ taxon: Homo sapiens
+
+: ONTIE:0003536
+apply template: protein class
+ label: biglycan
+ taxon: Homo sapiens
+
+: ONTIE:0003537
+apply template: protein class
+ label: Ov23
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003538
+apply template: protein class
+ label: Sec c 1
+ taxon: Secale cereale
+
+: ONTIE:0003539
+apply template: protein class
+ label: C-type lectin like protein
+ taxon: African swine fever virus
+alternative term: lectin homolog
+alternative term: Lectin-like protein EP153R
+alternative term: pEP153R
+
+: ONTIE:0003540
+apply template: protein class
+ label: permease
+ taxon: Leptospira interrogans
+
+: ONTIE:0003541
+apply template: protein class
+ label: Pn14TS
+ taxon: Streptococcus pneumoniae
+alternative term: S. pneumoniae serotype 14 capsular polysaccharide
+
+: ONTIE:0003542
+apply template: protein class
+ label: tissue transglutaminase
+ taxon: Homo sapiens
+alternative term: tTG
+
+: ONTIE:0003543
+apply template: protein class
+ label: beta-conglycinin alpha subunit
+ taxon: Glycine max
+
+: ONTIE:0003544
+apply template: protein class
+ label: tropomyosin
+ taxon: Crassostrea gigas
+alternative term: Cra g 1
+
+: ONTIE:0003545
+apply template: protein class
+ label: nuclear receptor ROR-gamma isoform X1
+ taxon: Homo sapiens
+
+: ONTIE:0003546
+apply template: protein class
+ label: mitochondrial import receptor Tom22 variant
+ taxon: Homo sapiens
+
+: ONTIE:0003547
+apply template: protein class
+ label: env protein
+ taxon: Homo sapiens
+
+: ONTIE:0003548
+apply template: protein class
+ label: MMP24 protein
+ taxon: Homo sapiens
+
+: ONTIE:0003549
+apply template: protein class
+ label: hCG1653259
+ taxon: Homo sapiens
+
+: ONTIE:0003550
+apply template: protein class
+ label: arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2
+ taxon: Homo sapiens
+
+: ONTIE:0003551
+apply template: protein class
+ label: cadherin-19
+ taxon: Homo sapiens
+
+: ONTIE:0003552
+apply template: protein class
+ label: hCG2038477
+ taxon: Homo sapiens
+
+: ONTIE:0003553
+apply template: protein class
+ label: cell division cycle protein 20 homolog B
+ taxon: Homo sapiens
+
+: ONTIE:0003554
+apply template: protein class
+ label: ephrin type-A receptor 3
+ taxon: Homo sapiens
+alternative term: EPH receptor A3
+
+: ONTIE:0003555
+apply template: protein class
+ label: basic helix-loop-helix domain-containing protein USF3
+ taxon: Homo sapiens
+alternative term: Upstream transcription factor 3
+
+: ONTIE:0003556
+apply template: protein class
+ label: hCG1980844
+ taxon: Homo sapiens
+
+: ONTIE:0003557
+apply template: protein class
+ label: selenoprotein N
+ taxon: Homo sapiens
+
+: ONTIE:0003558
+apply template: protein class
+ label: reverse transcriptase homolog - human retrotransposon L1
+ taxon: Homo sapiens
+alternative term: reverse transcriptase homolog - human transposon L1.1
+
+: ONTIE:0003559
+apply template: protein class
+ label: dermal papilla derived protein 6
+ taxon: Homo sapiens
+alternative term: DERP6
+
+: ONTIE:0003560
+apply template: protein class
+ label: 2'-5'-oligoadenylate synthase 2
+ taxon: Homo sapiens
+
+: ONTIE:0003561
+apply template: protein class
+ label: butyrophilin subfamily 2 member A2 isoform a
+ taxon: Homo sapiens
+
+: ONTIE:0003562
+apply template: protein class
+ label: protocadherin Fat 3
+ taxon: Homo sapiens
+
+: ONTIE:0003563
+apply template: protein class
+ label: zinc finger protein 638 isoform X5
+ taxon: Homo sapiens
+
+: ONTIE:0003564
+apply template: protein class
+ label: Transthyretin
+ taxon: Homo sapiens
+
+: ONTIE:0003565
+apply template: protein class
+ label: lipoxygenase homology domain-containing protein 1
+ taxon: Homo sapiens
+
+: ONTIE:0003566
+apply template: protein class
+ label: fusion glycoprotein
+ taxon: Bovine orthopneumovirus
+
+: ONTIE:0003567
+apply template: protein class
+ label: orexin
+ taxon: Homo sapiens
+
+: ONTIE:0003568
+apply template: protein class
+ label: large S protein
+ taxon: Hepatitis B virus
+
+: ONTIE:0003569
+apply template: protein class
+ label: pilin
+ taxon: Escherichia coli
+
+: ONTIE:0003570
+apply template: protein class
+ label: S100 calcium binding protein B
+ taxon: Homo sapiens
+
+: ONTIE:0003571
+apply template: protein class
+ label: Uncharacterized protein
+ taxon: Onchocerca volvulus
+
+: ONTIE:0003572
+apply template: protein class
+ label: matrix protein
+ taxon: Avian avulavirus 1
+
+: ONTIE:0003573
+apply template: protein class
+ label: VlsE
+ taxon: Borreliella afzelii
+
+: ONTIE:0003574
+apply template: protein class
+ label: Talin 1
+ taxon: Homo sapiens
+alternative term: Talin-1
+
+: ONTIE:0003575
+apply template: protein class
+ label: platelet derived growth factor receptor alpha
+ taxon: Homo sapiens
+alternative term: PDGFRA
+
+: ONTIE:0003576
+apply template: protein class
+ label: dual specificity protein phosphatase 3
+ taxon: Homo sapiens
+alternative term: DUSP3
+
+: ONTIE:0003577
+apply template: protein class
+ label: Serine/threonine-protein kinase STK11
+ taxon: Homo sapiens
+
+: ONTIE:0003578
+apply template: protein class
+ label: Cadherin EGF LAG seven-pass G-type receptor 1
+ taxon: Homo sapiens
+
+: ONTIE:0003579
+apply template: protein class
+ label: odorant response abnormal 4
+ taxon: Homo sapiens
+alternative term: protein odr-4 homolog
+
+: ONTIE:0003580
+apply template: protein class
+ label: Tyrosine-protein kinase ABL2
+ taxon: Homo sapiens
+
+: ONTIE:0003581
+apply template: protein class
+ label: Collagen alpha-1(XVI) chain
+ taxon: Homo sapiens
+
+: ONTIE:0003582
+apply template: protein class
+ label: guanylate cyclase soluble subunit alpha-3
+ taxon: Homo sapiens
+
+: ONTIE:0003583
+apply template: protein class
+ label: dual specificity mitogen-activated protein kinase kinase 4
+ taxon: Homo sapiens
+
+: ONTIE:0003584
+apply template: protein class
+ label: Putative methyltransferase NSUN3
+ taxon: Homo sapiens
+
+: ONTIE:0003585
+apply template: protein class
+ label: Putative glycosyltransferase ALG1-like
+ taxon: Homo sapiens
+
+: ONTIE:0003586
+apply template: protein class
+ label: phosphomannomutase 2
+ taxon: Homo sapiens
+
+: ONTIE:0003587
+apply template: protein class
+ label: Protein argonaute-2
+ taxon: Homo sapiens
+
+: ONTIE:0003588
+apply template: protein class
+ label: meningioma-expressed antigen 5s
+ taxon: Homo sapiens
+
+: ONTIE:0003589
+apply template: protein class
+ label: FtsJ-like protein 1
+ taxon: Homo sapiens
+
+: ONTIE:0003590
+apply template: protein class
+ label: Growth arrest-specific protein 6
+ taxon: Homo sapiens
+
+: ONTIE:0003591
+apply template: protein class
+ label: HEAT repeat-containing protein 2
+ taxon: Homo sapiens
+
+: ONTIE:0003592
+apply template: protein class
+ label: synaptojanin-2
+ taxon: Homo sapiens
+alternative term: synaptojanin 2
+
+: ONTIE:0003593
+apply template: protein class
+ label: sodium channel, nonvoltage-gated 1
+ taxon: Homo sapiens
+
+: ONTIE:0003594
+apply template: protein class
+ label: deoxyribonuclease I-like 1
+ taxon: Homo sapiens
+
+: ONTIE:0003595
+apply template: protein class
+ label: sec24D protein
+ taxon: Homo sapiens
+
+: ONTIE:0003596
+apply template: protein class
+ label: THEM6
+ taxon: Homo sapiens
+
+: ONTIE:0003597
+apply template: protein class
+ label: MYCBP2
+ taxon: Homo sapiens
+
+: ONTIE:0003598
+apply template: protein class
+ label: protein farnesyltransferase subunit beta
+ taxon: Homo sapiens
+
+: ONTIE:0003599
+apply template: protein class
+ label: Rb-associated protein
+ taxon: Homo sapiens
+alternative term: Rb associated protein
+
+: ONTIE:0003600
+apply template: protein class
+ label: splicing factor 3B
+ taxon: Homo sapiens
+
+: ONTIE:0003601
+apply template: protein class
+ label: GTPase NRas
+ taxon: Homo sapiens
+
+: ONTIE:0003602
+apply template: protein class
+ label: FAST kinase domain-containing protein 2
+ taxon: Homo sapiens
+alternative term: FAST kinase domain containing protein 2
+
+: ONTIE:0003603
+apply template: protein class
+ label: proteasomal ubiquitin receptor ADRM1
+ taxon: Homo sapiens
+alternative term: ADRM1
+
+: ONTIE:0003604
+apply template: protein class
+ label: angiotensin-converting enzyme isoform 1
+ taxon: Homo sapiens
+alternative term: angiotensin converting enzyme isoform 1
+
+: ONTIE:0003605
+apply template: protein class
+ label: Chromodomain-helicase-DNA-binding protein 1-like
+ taxon: Homo sapiens
+alternative term: Chromodomain helicase DNA binding protein 1 like
+
+: ONTIE:0003606
+apply template: protein class
+ label: Splicing regulatory glutamine/lysine-rich protein 1
+ taxon: Homo sapiens
+
+: ONTIE:0003607
+apply template: protein class
+ label: Receptor tyrosine protein kinase erbB-2
+ taxon: Homo sapiens
+alternative term: erbB 2
+
+: ONTIE:0003608
+apply template: protein class
+ label: adhesion G protein coupled receptor D1
+ taxon: Homo sapiens
+
+: ONTIE:0003609
+apply template: protein class
+ label: Lysine tRNA ligase
+ taxon: Homo sapiens
+
+: ONTIE:0003610
+apply template: protein class
+ label: Quinolinate phosphoribosyltransferase
+ taxon: Homo sapiens
+
+: ONTIE:0003611
+apply template: protein class
+ label: protein tyrosine sulfotransferase 1
+ taxon: Homo sapiens
+
+: ONTIE:0003612
+apply template: protein class
+ label: periodic tryptophan protein 2 homolog
+ taxon: Homo sapiens
+

--- a/ontology/ontie.kn
+++ b/ontology/ontie.kn
@@ -22308,445 +22308,70 @@ rank: no rank
 
 : ONTIE:0003455
 apply template: protein class
- label: band 3 anion transport protein
- taxon: Mus musculus
-
-: ONTIE:0003456
-apply template: protein class
- label: ubiquitin-associated domain-containing protein 2
- taxon: Homo sapiens
-
-: ONTIE:0003457
-apply template: protein class
- label: CD74/ROS
- taxon: Homo sapiens
-alternative term: CD74-TRKA
-
-: ONTIE:0003458
-apply template: protein class
- label: cyclin-dependent kinase 3
- taxon: Homo sapiens
-
-: ONTIE:0003459
-apply template: protein class
- label: Uncharacterized protein KIAA0754
- taxon: Homo sapiens
-
-: ONTIE:0003460
-apply template: protein class
- label: Major Peanut Allergen Ara H 6
- taxon: Arachis hypogaea
-alternative term: Conglutin
-
-: ONTIE:0003461
-apply template: protein class
- label: epsilon toxin
- taxon: Clostridium perfringens
-alternative term: epsilon-toxin
-
-: ONTIE:0003462
-apply template: protein class
- label: DNA processivity factor
- taxon: Human betaherpesvirus 5
-
-: ONTIE:0003463
-apply template: protein class
- label: synuclein
- taxon: Homo sapiens
-
-: ONTIE:0003464
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Sinonatrix annularis
-alternative term: PLIg
-
-: ONTIE:0003465
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Macropisthodon rudis
-
-: ONTIE:0003466
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Elaphe carinata
-
-: ONTIE:0003467
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Ptyas dhumnades
-
-: ONTIE:0003468
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Elaphe taeniura
-
-: ONTIE:0003469
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Lycodon rufozonatus
-alternative term: PLIg
-
-: ONTIE:0003470
-apply template: protein class
- label: phospholipase A2 inhibitor gamma
- taxon: Oocatochus rufodorsatus
-alternative term: PLIg
-
-: ONTIE:0003471
-apply template: protein class
- label: carbonate dehydratase
- taxon: Mycobacterium tuberculosis
-alternative term: carbonite dehydrogynase
-
-: ONTIE:0003472
-apply template: protein class
- label: glycoprotein G
- taxon: Human alphaherpesvirus 1
-
-: ONTIE:0003473
-apply template: protein class
- label: glycoprotein G
- taxon: Human alphaherpesvirus 2
-
-: ONTIE:0003474
-apply template: protein class
- label: holin
- taxon: Salmonella enterica
-
-: ONTIE:0003475
-apply template: protein class
- label: DNA polymerase III subunit gamma/tau
- taxon: Salmonella enterica
-
-: ONTIE:0003476
-apply template: protein class
- label: formate transporter FocA
- taxon: Salmonella enterica
-
-: ONTIE:0003477
-apply template: protein class
- label: phage baseplate protein
- taxon: Salmonella enterica
-
-: ONTIE:0003478
-apply template: protein class
- label: RNA helicase
- taxon: Salmonella enterica
-
-: ONTIE:0003479
-apply template: protein class
- label: valine tRNA ligase
- taxon: Salmonella enterica
-
-: ONTIE:0003480
-apply template: protein class
- label: hypothetical protein
- taxon: Salmonella enterica
-
-: ONTIE:0003481
-apply template: protein class
- label: PTS system mannitol-specific transporter subunit IIA
- taxon: Salmonella enterica
-
-: ONTIE:0003482
-apply template: protein class
- label: Zn-dependent protease
- taxon: Salmonella enterica
-
-: ONTIE:0003483
-apply template: protein class
- label: serine/threonine protein kinase
- taxon: Salmonella enterica
-
-: ONTIE:0003484
-apply template: protein class
- label: chloramphenicol/florfenicol efflux MFS transporter FloR
- taxon: Salmonella enterica
-
-: ONTIE:0003485
-apply template: protein class
- label: AraC family transcriptional regulator
- taxon: Salmonella enterica
-
-: ONTIE:0003486
-apply template: protein class
- label: glucosyltransferase
- taxon: Salmonella enterica
-
-: ONTIE:0003487
-apply template: protein class
- label: protein RarD
- taxon: Salmonella enterica
-
-: ONTIE:0003488
-apply template: protein class
- label: von Willebrand factor-cleaving protease precursor
- taxon: Homo sapiens
-
-: ONTIE:0003489
-apply template: protein class
- label: nucleocapsid protein
- taxon: Canine morbillivirus
-
-: ONTIE:0003490
-apply template: protein class
- label: Protocadherin-24 Ec1-3
- taxon: Mus musculus
-
-: ONTIE:0003491
-apply template: protein class
- label: collagen alpha-3(VI) chain
- taxon: Equus przewalskii
-
-: ONTIE:0003492
-apply template: protein class
- label: Collagen alpha-1(VII) chain
- taxon: Mus musculus
-
-: ONTIE:0003493
-apply template: protein class
- label: MF6p ortholog protein
- taxon: Paragonimus westermani
-
-: ONTIE:0003494
-apply template: protein class
- label: ATP synthase subunit beta
- taxon: Plasmodium berghei
-
-: ONTIE:0003495
-apply template: protein class
- label: ubiquitin carboxyl-terminal hydrolase 47
- taxon: Mus musculus
-
-: ONTIE:0003496
-apply template: protein class
- label: transcription factor 4
- taxon: Mus musculus
-
-: ONTIE:0003497
-apply template: protein class
- label: anaphase-promoting complex
- taxon: Mus musculus
-
-: ONTIE:0003498
-apply template: protein class
- label: solute carrier family 2, facilitated glucose transporter member 7
- taxon: Mus musculus
-
-: ONTIE:0003499
-apply template: protein class
- label: transmembrane protein vezatin
- taxon: Homo sapiens
-
-: ONTIE:0003500
-apply template: protein class
- label: Werner syndrome ATP-dependent helicase
- taxon: Homo sapiens
-
-: ONTIE:0003501
-apply template: protein class
- label: conserved Plasmodium protein
- taxon: Plasmodium berghei
-
-: ONTIE:0003502
-apply template: protein class
- label: hypothetical protein, conserved
- taxon: Leishmania donovani
-
-: ONTIE:0003503
-apply template: protein class
- label: potassium-transporting ATPase alpha chain 1
- taxon: Oryctolagus cuniculus
-
-: ONTIE:0003504
-apply template: protein class
- label: NACHT and WD repeat domain-containing protein 2
- taxon: Rattus norvegicus
-alternative term: Nwd2
-
-: ONTIE:0003505
-apply template: protein class
- label: collagen alpha-3(VI) chain
- taxon: Mus musculus
-
-: ONTIE:0003506
-apply template: protein class
- label: troponin T cardiac
- taxon: Carassius auratus
-
-: ONTIE:0003507
-apply template: protein class
- label: troponin T cardiac
- taxon: Melospiza melodia
-
-: ONTIE:0003508
-apply template: protein class
- label: Major surface glycoprotein G
- taxon: Human respiratory syncytial virus A
-
-: ONTIE:0003509
-apply template: protein class
- label: ORF9
- taxon: Porcine circovirus 2
-
-: ONTIE:0003510
-apply template: protein class
- label: pectate lyase
- taxon: Bacillus subtilis
-
-: ONTIE:0003511
-apply template: protein class
- label: triadin
- taxon: Homo sapiens
-
-: ONTIE:0003512
-apply template: protein class
- label: melanoma associated antigen
- taxon: Homo sapiens
-
-: ONTIE:0003513
-apply template: protein class
- label: Acetyl-coenzyme A synthetase ACSM6
- taxon: Homo sapiens
-alternative term: acetyl coenzyme A
-alternative term: synthetase
-alternative term: ACSM6
-
-: ONTIE:0003514
-apply template: protein class
- label: membrane glycoprotein UL40
- taxon: Human betaherpesvirus 5
-alternative term: UL40
-
-: ONTIE:0003515
-apply template: protein class
- label: retinoid isomerohydrolase isoform X1
- taxon: Bos taurus
-
-: ONTIE:0003516
-apply template: protein class
- label: non-structural protein 1 (NS1)
- taxon: Zika virus
-alternative term: NS1
-
-: ONTIE:0003517
-apply template: protein class
- label: urotensin II
- taxon: Neogobius melanostomus
-
-: ONTIE:0003518
-apply template: protein class
- label: large hepatitis delta antigen
- taxon: Hepatitis delta virus
-alternative term: L-HDAg
-
-: ONTIE:0003519
-apply template: protein class
- label: envelope glycoprotein
- taxon: Crimean-Congo hemorrhagic fever orthonairovirus
-
-: ONTIE:0003520
-apply template: protein class
- label: non-structural V protein
- taxon: Avian avulavirus 1
-
-: ONTIE:0003521
-apply template: protein class
- label: alcohol dehydrogenase
- taxon: Homo sapiens
-alternative term: ADH
-
-: ONTIE:0003522
-apply template: protein class
- label: arylphorin
- taxon: Galleria mellonella
-alternative term: Gal lysin-1
-
-: ONTIE:0003523
-apply template: protein class
- label: endoglucanase
- taxon: Clostridium beijerinckii
-
-: ONTIE:0003524
-apply template: protein class
- label: adenosine 5',5''',P1,P4-tetraphosphate receptor
- taxon: Mus musculus
-alternative term: Ap4A
-alternative term: adenosine 5',5"',P1,P4-tetraphosphate receptor
-
-: ONTIE:0003525
-apply template: protein class
- label: follitropin subunit beta
- taxon: Homo sapiens
-alternative term: follicle-stimulating hormone beta
-alternative term: FSHB
-
-: ONTIE:0003526
-apply template: protein class
  label: Ov-ASP-1
  taxon: Onchocerca volvulus
 
-: ONTIE:0003527
+: ONTIE:0003456
 apply template: protein class
  label: Ov-CHI-1
  taxon: Onchocerca volvulus
 
-: ONTIE:0003528
+: ONTIE:0003457
 apply template: protein class
  label: Ov-RBP-1
  taxon: Onchocerca volvulus
 
-: ONTIE:0003529
+: ONTIE:0003458
 apply template: protein class
  label: Ov-ALT-1
  taxon: Onchocerca volvulus
 
-: ONTIE:0003530
+: ONTIE:0003459
 apply template: protein class
  label: Ov-B20.16
  taxon: Onchocerca volvulus
 
-: ONTIE:0003531
+: ONTIE:0003460
 apply template: protein class
  label: Fibrinogen gamma chain
  taxon: Homo sapiens
 
-: ONTIE:0003532
+: ONTIE:0003461
 apply template: protein class
  label: FMRFamide precursor
  taxon: Macrocallista nimbosa
 
-: ONTIE:0003533
+: ONTIE:0003462
 apply template: protein class
  label: ferric reductase
  taxon: Escherichia coli
 
-: ONTIE:0003534
+: ONTIE:0003463
 apply template: protein class
  label: GNAT family N-acetyltransferase
  taxon: Yersinia enterocolitica
 
-: ONTIE:0003535
+: ONTIE:0003464
 apply template: protein class
  label: apolipoprotein E
  taxon: Homo sapiens
 
-: ONTIE:0003536
+: ONTIE:0003465
 apply template: protein class
  label: biglycan
  taxon: Homo sapiens
 
-: ONTIE:0003537
+: ONTIE:0003466
 apply template: protein class
  label: Ov23
  taxon: Onchocerca volvulus
 
-: ONTIE:0003538
+: ONTIE:0003467
 apply template: protein class
  label: Sec c 1
  taxon: Secale cereale
 
-: ONTIE:0003539
+: ONTIE:0003468
 apply template: protein class
  label: C-type lectin like protein
  taxon: African swine fever virus
@@ -22754,385 +22379,385 @@ alternative term: lectin homolog
 alternative term: Lectin-like protein EP153R
 alternative term: pEP153R
 
-: ONTIE:0003540
+: ONTIE:0003469
 apply template: protein class
  label: permease
  taxon: Leptospira interrogans
 
-: ONTIE:0003541
+: ONTIE:0003470
 apply template: protein class
  label: Pn14TS
  taxon: Streptococcus pneumoniae
 alternative term: S. pneumoniae serotype 14 capsular polysaccharide
 
-: ONTIE:0003542
+: ONTIE:0003471
 apply template: protein class
  label: tissue transglutaminase
  taxon: Homo sapiens
 alternative term: tTG
 
-: ONTIE:0003543
+: ONTIE:0003472
 apply template: protein class
  label: beta-conglycinin alpha subunit
  taxon: Glycine max
 
-: ONTIE:0003544
+: ONTIE:0003473
 apply template: protein class
  label: tropomyosin
  taxon: Crassostrea gigas
 alternative term: Cra g 1
 
-: ONTIE:0003545
+: ONTIE:0003474
 apply template: protein class
  label: nuclear receptor ROR-gamma isoform X1
  taxon: Homo sapiens
 
-: ONTIE:0003546
+: ONTIE:0003475
 apply template: protein class
  label: mitochondrial import receptor Tom22 variant
  taxon: Homo sapiens
 
-: ONTIE:0003547
+: ONTIE:0003476
 apply template: protein class
  label: env protein
  taxon: Homo sapiens
 
-: ONTIE:0003548
+: ONTIE:0003477
 apply template: protein class
  label: MMP24 protein
  taxon: Homo sapiens
 
-: ONTIE:0003549
+: ONTIE:0003478
 apply template: protein class
  label: hCG1653259
  taxon: Homo sapiens
 
-: ONTIE:0003550
+: ONTIE:0003479
 apply template: protein class
  label: arf-GAP with coiled-coil, ANK repeat and PH domain-containing protein 2
  taxon: Homo sapiens
 
-: ONTIE:0003551
+: ONTIE:0003480
 apply template: protein class
  label: cadherin-19
  taxon: Homo sapiens
 
-: ONTIE:0003552
+: ONTIE:0003481
 apply template: protein class
  label: hCG2038477
  taxon: Homo sapiens
 
-: ONTIE:0003553
+: ONTIE:0003482
 apply template: protein class
  label: cell division cycle protein 20 homolog B
  taxon: Homo sapiens
 
-: ONTIE:0003554
+: ONTIE:0003483
 apply template: protein class
  label: ephrin type-A receptor 3
  taxon: Homo sapiens
 alternative term: EPH receptor A3
 
-: ONTIE:0003555
+: ONTIE:0003484
 apply template: protein class
  label: basic helix-loop-helix domain-containing protein USF3
  taxon: Homo sapiens
 alternative term: Upstream transcription factor 3
 
-: ONTIE:0003556
+: ONTIE:0003485
 apply template: protein class
  label: hCG1980844
  taxon: Homo sapiens
 
-: ONTIE:0003557
+: ONTIE:0003486
 apply template: protein class
  label: selenoprotein N
  taxon: Homo sapiens
 
-: ONTIE:0003558
+: ONTIE:0003487
 apply template: protein class
  label: reverse transcriptase homolog - human retrotransposon L1
  taxon: Homo sapiens
 alternative term: reverse transcriptase homolog - human transposon L1.1
 
-: ONTIE:0003559
+: ONTIE:0003488
 apply template: protein class
  label: dermal papilla derived protein 6
  taxon: Homo sapiens
 alternative term: DERP6
 
-: ONTIE:0003560
+: ONTIE:0003489
 apply template: protein class
  label: 2'-5'-oligoadenylate synthase 2
  taxon: Homo sapiens
 
-: ONTIE:0003561
+: ONTIE:0003490
 apply template: protein class
  label: butyrophilin subfamily 2 member A2 isoform a
  taxon: Homo sapiens
 
-: ONTIE:0003562
+: ONTIE:0003491
 apply template: protein class
  label: protocadherin Fat 3
  taxon: Homo sapiens
 
-: ONTIE:0003563
+: ONTIE:0003492
 apply template: protein class
  label: zinc finger protein 638 isoform X5
  taxon: Homo sapiens
 
-: ONTIE:0003564
+: ONTIE:0003493
 apply template: protein class
  label: Transthyretin
  taxon: Homo sapiens
 
-: ONTIE:0003565
+: ONTIE:0003494
 apply template: protein class
  label: lipoxygenase homology domain-containing protein 1
  taxon: Homo sapiens
 
-: ONTIE:0003566
+: ONTIE:0003495
 apply template: protein class
  label: fusion glycoprotein
  taxon: Bovine orthopneumovirus
 
-: ONTIE:0003567
+: ONTIE:0003496
 apply template: protein class
  label: orexin
  taxon: Homo sapiens
 
-: ONTIE:0003568
+: ONTIE:0003497
 apply template: protein class
  label: large S protein
  taxon: Hepatitis B virus
 
-: ONTIE:0003569
+: ONTIE:0003498
 apply template: protein class
  label: pilin
  taxon: Escherichia coli
 
-: ONTIE:0003570
+: ONTIE:0003499
 apply template: protein class
  label: S100 calcium binding protein B
  taxon: Homo sapiens
 
-: ONTIE:0003571
+: ONTIE:0003500
 apply template: protein class
  label: Uncharacterized protein
  taxon: Onchocerca volvulus
 
-: ONTIE:0003572
+: ONTIE:0003501
 apply template: protein class
  label: matrix protein
  taxon: Avian avulavirus 1
 
-: ONTIE:0003573
+: ONTIE:0003502
 apply template: protein class
  label: VlsE
  taxon: Borreliella afzelii
 
-: ONTIE:0003574
+: ONTIE:0003503
 apply template: protein class
  label: Talin 1
  taxon: Homo sapiens
 alternative term: Talin-1
 
-: ONTIE:0003575
+: ONTIE:0003504
 apply template: protein class
  label: platelet derived growth factor receptor alpha
  taxon: Homo sapiens
 alternative term: PDGFRA
 
-: ONTIE:0003576
+: ONTIE:0003505
 apply template: protein class
  label: dual specificity protein phosphatase 3
  taxon: Homo sapiens
 alternative term: DUSP3
 
-: ONTIE:0003577
+: ONTIE:0003506
 apply template: protein class
  label: Serine/threonine-protein kinase STK11
  taxon: Homo sapiens
 
-: ONTIE:0003578
+: ONTIE:0003507
 apply template: protein class
  label: Cadherin EGF LAG seven-pass G-type receptor 1
  taxon: Homo sapiens
 
-: ONTIE:0003579
+: ONTIE:0003508
 apply template: protein class
  label: odorant response abnormal 4
  taxon: Homo sapiens
 alternative term: protein odr-4 homolog
 
-: ONTIE:0003580
+: ONTIE:0003509
 apply template: protein class
  label: Tyrosine-protein kinase ABL2
  taxon: Homo sapiens
 
-: ONTIE:0003581
+: ONTIE:0003510
 apply template: protein class
  label: Collagen alpha-1(XVI) chain
  taxon: Homo sapiens
 
-: ONTIE:0003582
+: ONTIE:0003511
 apply template: protein class
  label: guanylate cyclase soluble subunit alpha-3
  taxon: Homo sapiens
 
-: ONTIE:0003583
+: ONTIE:0003512
 apply template: protein class
  label: dual specificity mitogen-activated protein kinase kinase 4
  taxon: Homo sapiens
 
-: ONTIE:0003584
+: ONTIE:0003513
 apply template: protein class
  label: Putative methyltransferase NSUN3
  taxon: Homo sapiens
 
-: ONTIE:0003585
+: ONTIE:0003514
 apply template: protein class
  label: Putative glycosyltransferase ALG1-like
  taxon: Homo sapiens
 
-: ONTIE:0003586
+: ONTIE:0003515
 apply template: protein class
  label: phosphomannomutase 2
  taxon: Homo sapiens
 
-: ONTIE:0003587
+: ONTIE:0003516
 apply template: protein class
  label: Protein argonaute-2
  taxon: Homo sapiens
 
-: ONTIE:0003588
+: ONTIE:0003517
 apply template: protein class
  label: meningioma-expressed antigen 5s
  taxon: Homo sapiens
 
-: ONTIE:0003589
+: ONTIE:0003518
 apply template: protein class
  label: FtsJ-like protein 1
  taxon: Homo sapiens
 
-: ONTIE:0003590
+: ONTIE:0003519
 apply template: protein class
  label: Growth arrest-specific protein 6
  taxon: Homo sapiens
 
-: ONTIE:0003591
+: ONTIE:0003520
 apply template: protein class
  label: HEAT repeat-containing protein 2
  taxon: Homo sapiens
 
-: ONTIE:0003592
+: ONTIE:0003521
 apply template: protein class
  label: synaptojanin-2
  taxon: Homo sapiens
 alternative term: synaptojanin 2
 
-: ONTIE:0003593
+: ONTIE:0003522
 apply template: protein class
  label: sodium channel, nonvoltage-gated 1
  taxon: Homo sapiens
 
-: ONTIE:0003594
+: ONTIE:0003523
 apply template: protein class
  label: deoxyribonuclease I-like 1
  taxon: Homo sapiens
 
-: ONTIE:0003595
+: ONTIE:0003524
 apply template: protein class
  label: sec24D protein
  taxon: Homo sapiens
 
-: ONTIE:0003596
+: ONTIE:0003525
 apply template: protein class
  label: THEM6
  taxon: Homo sapiens
 
-: ONTIE:0003597
+: ONTIE:0003526
 apply template: protein class
  label: MYCBP2
  taxon: Homo sapiens
 
-: ONTIE:0003598
+: ONTIE:0003527
 apply template: protein class
  label: protein farnesyltransferase subunit beta
  taxon: Homo sapiens
 
-: ONTIE:0003599
+: ONTIE:0003528
 apply template: protein class
  label: Rb-associated protein
  taxon: Homo sapiens
 alternative term: Rb associated protein
 
-: ONTIE:0003600
+: ONTIE:0003529
 apply template: protein class
  label: splicing factor 3B
  taxon: Homo sapiens
 
-: ONTIE:0003601
+: ONTIE:0003530
 apply template: protein class
  label: GTPase NRas
  taxon: Homo sapiens
 
-: ONTIE:0003602
+: ONTIE:0003531
 apply template: protein class
  label: FAST kinase domain-containing protein 2
  taxon: Homo sapiens
 alternative term: FAST kinase domain containing protein 2
 
-: ONTIE:0003603
+: ONTIE:0003532
 apply template: protein class
  label: proteasomal ubiquitin receptor ADRM1
  taxon: Homo sapiens
 alternative term: ADRM1
 
-: ONTIE:0003604
+: ONTIE:0003533
 apply template: protein class
  label: angiotensin-converting enzyme isoform 1
  taxon: Homo sapiens
 alternative term: angiotensin converting enzyme isoform 1
 
-: ONTIE:0003605
+: ONTIE:0003534
 apply template: protein class
  label: Chromodomain-helicase-DNA-binding protein 1-like
  taxon: Homo sapiens
 alternative term: Chromodomain helicase DNA binding protein 1 like
 
-: ONTIE:0003606
+: ONTIE:0003535
 apply template: protein class
  label: Splicing regulatory glutamine/lysine-rich protein 1
  taxon: Homo sapiens
 
-: ONTIE:0003607
+: ONTIE:0003536
 apply template: protein class
  label: Receptor tyrosine protein kinase erbB-2
  taxon: Homo sapiens
 alternative term: erbB 2
 
-: ONTIE:0003608
+: ONTIE:0003537
 apply template: protein class
  label: adhesion G protein coupled receptor D1
  taxon: Homo sapiens
 
-: ONTIE:0003609
+: ONTIE:0003538
 apply template: protein class
  label: Lysine tRNA ligase
  taxon: Homo sapiens
 
-: ONTIE:0003610
+: ONTIE:0003539
 apply template: protein class
  label: Quinolinate phosphoribosyltransferase
  taxon: Homo sapiens
 
-: ONTIE:0003611
+: ONTIE:0003540
 apply template: protein class
  label: protein tyrosine sulfotransferase 1
  taxon: Homo sapiens
 
-: ONTIE:0003612
+: ONTIE:0003541
 apply template: protein class
  label: periodic tryptophan protein 2 homolog
  taxon: Homo sapiens

--- a/src/add-new-terms.py
+++ b/src/add-new-terms.py
@@ -115,11 +115,11 @@ def main():
 		print("{} new proteins added".format(proteins_added))
 
 	# Maybe write new external table
-	with open('ontology/external.tsv', 'a') as ext:
+	with open(external_path, 'a') as ext:
 		ext_added = 0
 		for key in sorted(new_external.keys()):
 			ext_added += 1
-			ext.write('%s	%s	owl:Class\n' % (key, new_external[key]))
+			ext.write('%s	%s	owl:Class\n' % (new_external[key], key))
 	if ext_added > 0:
 		print("{} new external classes added".format(ext_added))
 
@@ -235,7 +235,7 @@ def init_data():
 	if os.path.exists(external_path):
 		with open(external_path, 'r') as ext:
 			for line in ext:
-				(label, curie, rdf_type) = line.split('\t')
+				(curie, label, rdf_type) = line.split('\t')
 				external[label] = curie
 
 	if os.path.exists(organism_map_path):


### PR DESCRIPTION
10 new organisms added:
* `ONTIE:0003445`	Enterovirus D68 Kunming	
* `ONTIE:0003446`	Enterovirus D68 Fermon		
* `ONTIE:0003447`	Babesia bovis T3Bo	
* `ONTIE:0003448`	Leishmania amazonensis MHOM/BR/73/M2269
* `ONTIE:0003449`	Leishmania braziliensis MHOM/BR/94/M2903
* `ONTIE:0003450`	Yellow fever virus CNYF01/2016
* `ONTIE:0003451`	Fowlpox virus FP9
* `ONTIE:0003452`	Salmonella enterica subsp. enterica serovar Typhi str. Quailes	
* `ONTIE:0003453`	Salmonella enterica subsp. enterica serovar Paratyphi A str. NVGH308
* `ONTIE:0003454`	Enterobacteria phage PRD1

87 new proteins added (see [index.tsv](https://github.com/IEDB/ONTIE/blob/c6e7182665f4fc84581129c543c7063826a9df36/ontology/index.tsv) for all of them)
* `ONTIE:0003455` Ov-ASP-1 (Onchocerca volvulus)
* ... through ...
* `ONTIE:0003541` periodic tryptophan protein 2 homolog (Homo sapiens)

3 new external classes added
* `NCBITaxon:42789`	Enterovirus D68
* `NCBITaxon:10261`	Fowlpox virus
* `NCBITaxon:2169700`	Pseudomonas virus PRD1

Fixed `src/add-new-terms.py` to switch the CURIE and Label columns for `ontology/external.tsv`.

Lines 3303 through 3341 of `ontology/index.tsv` were previously duplicated three times. I removed the extra two sets of terms.