### PR TITLE
First pass at HTML forms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM obolibrary/odkfull
+
+COPY requirements.txt /tools/ontie-requirements.txt
+RUN pip install -r /tools/ontie-requirements.txt
+
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get install -y git
+
+RUN apt-get install -y aha

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ all: test
 
 # Create a new Google sheet with branch name & share it with provided email
 
-COGS_SHEETS := $(foreach S,$(SHEETS),.cogs/$(S).tsv)
+COGS_SHEETS := $(foreach S,$(SHEETS),.cogs/tracked/$(S).tsv)
 
 .PHONY: load
 load: $(COGS_SHEETS)
@@ -182,7 +182,7 @@ load: $(COGS_SHEETS)
 	sed s/0/2/ sheet.tsv > .cogs/sheet.tsv
 	rm sheet.tsv
 
-.cogs/%.tsv: src/ontology/templates/%.tsv | .cogs
+.cogs/tracked/%.tsv: src/ontology/templates/%.tsv | .cogs
 	$(COGS) add $<
 
 .PHONY: push

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
 ### Workflow
 #
-# 1. [Edit](./src/scripts/cogs.sh) the Google Sheet
+# #### Edit existing terms
+# 1. [Edit all templates](./src/scripts/cogs.sh) the Google Sheet
 # 2. [Validate](validate) sheet
+#
+# #### Add a new term
+# - [assays](./src/scripts/generate-form.sh?template=assays)
+# - [complex](./src/scripts/generate-form.sh?template=complex)
+# - [disease](./src/scripts/generate-form.sh?template=disease)
+# - [other](./src/scripts/generate-form.sh?template=other)
+# - [protein](./src/scripts/generate-form.sh?template=protein)
+# - [taxon](./src/scripts/generate-form.sh?template=taxon)
+#
+# #### Review changes
 # 3. [View table diffs](build/diff/diff.html)
 # 4. [Update](update) ontology files
 # 5. View the results:
@@ -9,7 +20,7 @@
 #     - [Browse Trees](./src/scripts/tree.sh)
 #     - [Download ontie.owl](ontie.owl)
 #
-# ### Commit Changes
+# #### Commit Changes
 #
 # 1. Run [Status](git status) to see changes
 # 2. Run [Commit](git commit) and enter message

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,12 @@ build/%.db: src/scripts/prefixes.sql build/%.owl | build/rdftab
 	rm -rf $@
 	sqlite3 $@ < $<
 	./build/rdftab $@ < $(word 2,$^)
+	sqlite3 $@ "CREATE INDEX idx_stanza ON statements (stanza);"
+	sqlite3 $@ "CREATE INDEX idx_subject ON statements (subject);"
+	sqlite3 $@ "CREATE INDEX idx_predicate ON statements (predicate);"
+	sqlite3 $@ "CREATE INDEX idx_object ON statements (object);"
+	sqlite3 $@ "CREATE INDEX idx_value ON statements (value);"
+	sqlite3 $@ "ANALYZE;"
 
 build/terms.txt: src/ontology/templates/external.tsv | build
 	awk -F '\t' '{print $$1}' $< | tail -n +3 | sed '/NCBITaxon:/d' > $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ontodev-gizmos
+urlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+git+https://github.com/ontodev/valve.py.git
 ontodev-gizmos
 urlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/ontodev/valve.py.git
-ontodev-gizmos
+git+https://github.com/ontodev/gizmos.git
 urlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/ontodev/valve.py.git
 git+https://github.com/ontodev/gizmos.git
 urlp
+psycopg2

--- a/src/ontology/templates/disease.tsv
+++ b/src/ontology/templates/disease.tsv
@@ -31,7 +31,7 @@ habitual abortion	female reproductive system disease	A female reproductive syste
 healthy	host health status	The absence of any disease	U6	disease		
 host health status	owl:Thing	The state of the host at the time of the experiment		disease		
 human T-lymphotropic virus 1 carrier	infection without disease	An asymptomatic infection with Human T-cell leukemia virus type I.	HTLV-1 carrier|Z22.6	disease	Human T-cell leukemia virus type I	
-infection without disease	host health status	The presence of an infection in a host that does not manifest in any pathological processes.	asymptomatic infection	disease	
+infection without disease	host health status	The presence of an infection in a host that does not manifest in any pathological processes.	asymptomatic infection	disease		
 rejection of transplanted organs and tissues	transplant-related disease and allo-reactivity	A transplant-related disease and allo-reactivity that results in rejection of the transplanted tissue or blood.	T86|T86.0|T86.1|T86.2|T86.3|T86.8	disease		
-transplant-related disease and allo-reactivity	disease	A disease that results from transplantation or allo-reactivity.		disease			
+transplant-related disease and allo-reactivity	disease	A disease that results from transplantation or allo-reactivity.		disease		
 syndrome	additional diseases by category					

--- a/src/scripts/add-term.py
+++ b/src/scripts/add-term.py
@@ -1,0 +1,79 @@
+import csv
+
+from argparse import ArgumentParser
+from urllib.parse import parse_qs
+
+
+DEFAULTS = ["add", "branch", "branch-name", "project-name", "view-path"]
+
+
+def main():
+	parser = ArgumentParser()
+	parser.add_argument("query_string")
+	args = parser.parse_args()
+
+	fields = parse_qs(args.query_string)
+	for default in DEFAULTS:
+		if default in fields:
+			del fields[default]
+
+	fields = {k: v[0] for k, v in fields.items()}
+
+	template = None
+	if "template" in fields:
+		template = fields["template"]
+		del fields["template"]
+	term_id = None
+	if "ID" in fields:
+		term_id = fields["ID"]
+		del fields["ID"]
+
+	if not template:
+		print("Unable to add term; missing template name")
+		return
+	if not term_id:
+		print("Unable to add term; an ID is required")
+		return
+	if not fields.get("Label"):
+		print("Unable to add term; a Label is required")
+		return
+
+	template_path = f"src/ontology/templates/{template}.tsv"
+
+	rows = []
+	with open("src/ontology/templates/index.tsv", "r") as fr:
+		reader = csv.DictReader(fr, delimiter="\t")
+		header = reader.fieldnames
+		for row in reader:
+			this_id = row["ID"]
+			if this_id == term_id:
+				this_label = row["Label"]
+				print(f"Unable to add term; a term already exists with ID {term_id} ({this_label})")
+				return
+			rows.append(row)
+	rows.append({"ID": term_id, "Label": fields.get("Label"), "Type": "owl:Class"})
+
+	with open("src/ontology/templates/index.tsv", "w") as fw:
+		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n")
+		writer.writeheader()
+		writer.writerows(rows)
+
+	rows = []
+	with open(template_path, "r") as fr:
+		reader = csv.DictReader(fr, delimiter="\t")
+		header = reader.fieldnames
+		for row in reader:
+			rows.append(row)
+	rows.append(fields)
+
+	with open(template_path, "w") as fw:
+		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n")
+		writer.writeheader()
+		writer.writerows(rows)
+
+	print(f"{term_id} added to ONITE!")
+
+
+if __name__ == '__main__':
+	main()
+

--- a/src/scripts/cogs.sh
+++ b/src/scripts/cogs.sh
@@ -5,6 +5,11 @@
 
 echo "Content-Type: text/html"
 echo ""
+echo '<head>'
+echo '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">'
+echo '</head>'
+echo '<body>'
+echo '<div class="container" style="padding-top:20px;">'
 
 cd ../..
 
@@ -14,21 +19,20 @@ EMAIL=$(urlp --query --query_field=email "${URL}")
 BRANCH=$(git branch --show-current)
 INVALID=$(urlp --query --query_field=invalid "${URL}")
 
-if [[ ${EMAIL} ]]; then
-  TITLE="ONTIE ${BRANCH}"
-  if [[ ${EMAIL} =~ ${EMAIL_PAT} ]]; then
-    echo "<div class='alert alert-primary'>Creating a Google Sheet and sharing it with ${EMAIL}...</div>"
-    cogs init -t "${TITLE}" -u ${EMAIL} -r writer
-    make load push
-  else
-    echo '<meta http-equiv="refresh" content="0; ?invalid=true"/>'
-  fi
-fi
-
 if [ -d .cogs ]; then
   LINK=$(cogs open)
   echo "<meta http-equiv='refresh' content='0; ${LINK}'/>"
   exit 0
+fi
+
+if [[ ${EMAIL} ]]; then
+  TITLE="ONTIE ${BRANCH}"
+  if [[ ${EMAIL} =~ ${EMAIL_PAT} ]]; then
+    cogs init -c credentials.json -t "${TITLE}" -u ${EMAIL} -r writer || exit 1
+    make load push || exit 1
+  else
+    echo '<meta http-equiv="refresh" content="0; ?invalid=true"/>'
+  fi
 fi
 
 if [[ ${INVALID} ]]; then
@@ -40,3 +44,5 @@ echo 'Google account (email):'
 echo '<input name="email" type="text"/>'
 echo '<input type="submit"/>'
 echo '</form>'
+echo '</div>'
+echo '</body>'

--- a/src/scripts/cogs.sh
+++ b/src/scripts/cogs.sh
@@ -17,7 +17,7 @@ INVALID=$(urlp --query --query_field=invalid "${URL}")
 if [[ ${EMAIL} ]]; then
   TITLE="ONTIE ${BRANCH}"
   if [[ ${EMAIL} =~ ${EMAIL_PAT} ]]; then
-	echo "<div class='alert alert-primary'>Creating a Google Sheet and sharing it with ${EMAIL}...</div>"
+    echo "<div class='alert alert-primary'>Creating a Google Sheet and sharing it with ${EMAIL}...</div>"
     cogs init -t "${TITLE}" -u ${EMAIL} -r writer
     make load push
   else

--- a/src/scripts/form.html
+++ b/src/scripts/form.html
@@ -8,47 +8,8 @@
         <!-- Bootstrap CSS -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
         <style>
-        #annotations {
-          padding-left: 1em;
-          list-style-type: none !important;
-        }
-        #annotations ul {
-          padding-left: 3em;
-          list-style-type: circle !important;
-        }
-        #annotations ul ul {
-          padding-left: 2em;
-          list-style-type: none !important;
-        }
-        .hierarchy {
-          padding-left: 0em;
-          list-style-type: none !important;
-        }
-        .hierarchy ul {
-          padding-left: 1em;
-          list-style-type: none !important;
-        }
-        .hierarchy ul.multiple-children > li > ul {
-          border-left: 1px dotted #ddd;
-        }
-        .hierarchy .children {
-          border-left: none;
-          margin-left: 2em;
-          text-indent: -1em;
-        }
-        .hierarchy .children li::before {
-          content: "\2022";
-          color: #ddd;
-          display: inline-block;
-          width: 0em;
-          margin-left: -1em;
-        }
         a {
           text-decoration: none;
-        }
-        #nonpeptides .tt-dataset {
-          max-height: 300px;
-          overflow-y: scroll;
         }
         table {
           display: block;
@@ -157,17 +118,6 @@
       <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js"></script>
       <script type="text/javascript">
-        function show_children() {
-          hidden = $('#children li:hidden').slice(0, 100);
-          if (hidden.length > 1) {
-              hidden.show();
-              setTimeout(show_children, 100);
-          } else {
-              console.log("DONE");
-          }
-          $('#more').hide();
-        }
-
         $('#search-form').submit(function () {
             $(this)
                 .find('input[name]')

--- a/src/scripts/form.html
+++ b/src/scripts/form.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+        <!-- Bootstrap CSS -->
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+        <style>
+        #annotations {
+          padding-left: 1em;
+          list-style-type: none !important;
+        }
+        #annotations ul {
+          padding-left: 3em;
+          list-style-type: circle !important;
+        }
+        #annotations ul ul {
+          padding-left: 2em;
+          list-style-type: none !important;
+        }
+        .hierarchy {
+          padding-left: 0em;
+          list-style-type: none !important;
+        }
+        .hierarchy ul {
+          padding-left: 1em;
+          list-style-type: none !important;
+        }
+        .hierarchy ul.multiple-children > li > ul {
+          border-left: 1px dotted #ddd;
+        }
+        .hierarchy .children {
+          border-left: none;
+          margin-left: 2em;
+          text-indent: -1em;
+        }
+        .hierarchy .children li::before {
+          content: "\2022";
+          color: #ddd;
+          display: inline-block;
+          width: 0em;
+          margin-left: -1em;
+        }
+        a {
+          text-decoration: none;
+        }
+        #nonpeptides .tt-dataset {
+          max-height: 300px;
+          overflow-y: scroll;
+        }
+        table {
+          display: block;
+          max-width: -moz-fit-content;
+          max-width: fit-content;
+          margin: 0 auto;
+          overflow-x: auto;
+          white-space: nowrap;
+        }
+        span.twitter-typeahead .tt-menu {
+          cursor: pointer;
+        }
+        .dropdown-menu, span.twitter-typeahead .tt-menu {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          z-index: 1000;
+          display: none;
+          float: left;
+          min-width: 160px;
+          padding: 5px 0;
+          margin: 2px 0 0;
+          font-size: 1rem;
+          color: #373a3c;
+          text-align: left;
+          list-style: none;
+          background-color: #fff;
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.15);
+          border-radius: 0.25rem; }
+        span.twitter-typeahead .tt-suggestion {
+          display: block;
+          width: 100%;
+          padding: 3px 20px;
+          clear: both;
+          font-weight: normal;
+          line-height: 1.5;
+          color: #373a3c;
+          text-align: inherit;
+          white-space: nowrap;
+          background: none;
+          border: 0; }
+        span.twitter-typeahead .tt-suggestion:focus,
+        .dropdown-item:hover,
+        span.twitter-typeahead .tt-suggestion:hover {
+            color: #2b2d2f;
+            text-decoration: none;
+            background-color: #f5f5f5; }
+        span.twitter-typeahead .active.tt-suggestion,
+        span.twitter-typeahead .tt-suggestion.tt-cursor,
+        span.twitter-typeahead .active.tt-suggestion:focus,
+        span.twitter-typeahead .tt-suggestion.tt-cursor:focus,
+        span.twitter-typeahead .active.tt-suggestion:hover,
+        span.twitter-typeahead .tt-suggestion.tt-cursor:hover {
+            color: #fff;
+            text-decoration: none;
+            background-color: #0275d8;
+            outline: 0; }
+        span.twitter-typeahead .disabled.tt-suggestion,
+        span.twitter-typeahead .disabled.tt-suggestion:focus,
+        span.twitter-typeahead .disabled.tt-suggestion:hover {
+            color: #818a91; }
+        span.twitter-typeahead .disabled.tt-suggestion:focus,
+        span.twitter-typeahead .disabled.tt-suggestion:hover {
+            text-decoration: none;
+            cursor: not-allowed;
+            background-color: transparent;
+            background-image: none;
+            filter: "progid:DXImageTransform.Microsoft.gradient(enabled = false)"; }
+        span.twitter-typeahead {
+          width: 100%; }
+          .input-group span.twitter-typeahead {
+            display: block !important; }
+            .input-group span.twitter-typeahead .tt-menu {
+              top: 2.375rem !important; }
+        </style>
+
+        <title>New {{ title }} term</title>
+    </head>
+    <body>
+      <div class="container">
+      <div class="row" style="padding-top:25px;">
+        <h3>New {{ title }} term</h3>
+        <p style="color: #6c757d">All fields marked with * are required.</p>
+        <hr>
+      </div>
+      {{ message | safe }}
+      <div class="row justify-content-md-center" style="padding-top:10px; padding-bottom:20px;">
+        <div class="col-md-10">
+          <form class="needs-validation" method="get" novalidate>
+            <input type="hidden" name="add" value="true">
+            <input type="hidden" name="template" value="{{ title }}">
+            <h3 style="padding-bottom:20px;">Term Metadata</h3>
+            {{ metadata | safe }}
+            <hr>
+            <h3>Logical Defintion</h3>
+            <p style="padding-bottom: 20px; color: #6c757d;">All terms used in the logical definitions <b>must</b> exist in ONTIE.</p>
+            {{ logic | safe }}
+            <button type="submit" class="btn btn-large btn-outline-primary">Submit</button>
+          </form>
+        </div>
+      </div>
+    </div>
+      <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
+      <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js"></script>
+      <script type="text/javascript">
+        function show_children() {
+          hidden = $('#children li:hidden').slice(0, 100);
+          if (hidden.length > 1) {
+              hidden.show();
+              setTimeout(show_children, 100);
+          } else {
+              console.log("DONE");
+          }
+          $('#more').hide();
+        }
+
+        $('#search-form').submit(function () {
+            $(this)
+                .find('input[name]')
+                .filter(function () {
+                    return !this.value;
+                })
+                .prop('name', '');
+        });
+
+        function jump(currentPage) {
+          newPage = prompt("Jump to page", currentPage);
+          if (newPage) {
+            href = window.location.href.replace("page="+currentPage, "page="+newPage);
+            window.location.href = href;
+          }
+        }
+        // Configure typeahead for Parent labels
+        function configure_typeahead_obi(node) {
+          if (!node.id || !node.id.endsWith("-typeahead-obi")) {
+            return;
+          }
+          table = node.id.replace("-typeahead", "");
+          var bloodhound = new Bloodhound({
+            datumTokenizer: Bloodhound.tokenizers.obj.nonword('label'),
+            queryTokenizer: Bloodhound.tokenizers.nonword,
+            sorter: function(a, b) {
+              return a.order - b.order;
+            },
+            remote: {
+              url: '/ONTIE/branches/{{ branch }}/views/src/scripts/tree.sh?db=ontie&format=json&text=%QUERY',
+              wildcard: '%QUERY',
+              transform : function(response) {
+                return bloodhound.sorter(response);
+              }
+            }
+          });
+          $(node).typeahead({
+            minLength: 0,
+            hint: false,
+            highlight: true
+          }, {
+            name: table,
+            source: bloodhound,
+            display: function(item) {
+              return item.label;
+            },
+            limit: 40
+          });
+          $(node).bind('click', function(e) {
+            $(node).select();
+          });
+        }
+        $('.typeahead').each(function() { configure_typeahead_obi(this); });
+        function configure_typeahead(node) {
+          if (!node.id || !node.id.endsWith("-typeahead")) {
+            return;
+          }
+          table = node.id.replace("-typeahead", "");
+          var bloodhound = new Bloodhound({
+            datumTokenizer: Bloodhound.tokenizers.obj.nonword('short_label', 'label', 'synonym'),
+            queryTokenizer: Bloodhound.tokenizers.nonword,
+            sorter: function(a, b) {
+              return a.order - b.order;
+            },
+            remote: {
+              url: '/ONTIE/branches/{{ branch }}/views/src/scripts/tree.sh?db=ontie&format=json&text=%QUERY',
+              wildcard: '%QUERY',
+              transform : function(response) {
+                  return bloodhound.sorter(response);
+              }
+            }
+          });
+          $(node).typeahead({
+            minLength: 0,
+            hint: false,
+            highlight: true
+          }, {
+            name: table,
+            source: bloodhound,
+            display: function(item) {
+              if (item.label && item.short_label && item.synonym) {
+                return item.short_label + ' - ' + item.label + ' - ' + item.synonym;
+              } else if (item.label && item.short_label) {
+                return item.short_label + ' - ' + item.label;
+              } else if (item.label && item.synonym) {
+                return item.label + ' - ' + item.synonym;
+              } else if (item.short_label && item.synonym) {
+                return item.short_label + ' - ' + item.synonym;
+              } else if (item.short_label && !item.label) {
+                return item.short_label;
+              } else {
+                return item.label;
+              }
+            },
+            limit: 40
+          });
+          $(node).bind('click', function(e) {
+            $(node).select();
+          });
+          $(node).bind('typeahead:select', function(ev, suggestion) {
+            $(node).prev().val(suggestion.id);
+            go(table, suggestion.id);
+          });
+          $(node).bind('keypress',function(e) {
+            if(e.which == 13) {
+              go(table, $('#' + table + '-hidden').val());
+            }
+          });
+        }
+        $('.typeahead').each(function() { configure_typeahead(this); });
+        function go(table, value) {
+          q = {};
+          table = table.replace('_all', '');
+          q[table] = value;
+          window.location = query(q);
+        }
+        function query(obj) {
+          var str = [];
+          for (var p in obj)
+            if (obj.hasOwnProperty(p)) {
+              return "./" + encodeURIComponent(obj[p]);
+            }
+        }
+      </script>
+    </body>
+  </html>

--- a/src/scripts/generate-form.py
+++ b/src/scripts/generate-form.py
@@ -1,0 +1,161 @@
+import csv
+
+from argparse import ArgumentParser
+from jinja2 import Template
+
+
+def build_form_field(input_type, column, help_msg, required, value=None):
+    """Return an HTML form field for a template field."""
+    if required:
+        display = column + " *"
+    else:
+        display = column
+
+    html = [
+        '<div class="row mb-3">',
+        f'\t<label class="col-sm-2 col-form-label">{display}</label>',
+        '\t<div class="col-sm-10">',
+    ]
+
+    field_name = column.replace(" ", "-")
+
+    value_html = ""
+    if value:
+        value_html = f' value="{value}"'
+    if not value:
+        value = ""
+
+    if input_type == "text":
+        if required:
+            html.append(
+                f'\t\t<input type="text" class="form-control" name="{field_name}" required{value_html}>'
+            )
+            html.append('\t\t<div class="invalid-feedback">')
+            html.append(f"\t\t\t{column} is required")
+            html.append("</div>")
+        else:
+            html.append(
+                f'\t\t<input type="text" class="form-control" name="{field_name}"{value_html}>'
+            )
+
+    elif input_type == "textarea":
+        if required:
+            html.append(
+                f'\t\t<textarea class="form-control" name="{field_name}" rows="3" required>{value}</textarea>'
+            )
+            html.append('\t\t<div class="invalid-feedback">')
+            html.append(f"\t\t\t{column} is required")
+            html.append("</div>")
+        else:
+            html.append(
+                f'\t\t<textarea class="form-control" name="{field_name}" rows="3">{value}</textarea>'
+            )
+
+    elif input_type == "search":
+        if required:
+            html.append(
+                f'<input type="text" class="search form-control" name="{field_name}" '
+                + f'id="{field_name}-typeahead-obi" required{value_html}>'
+            )
+            html.append('\t\t<div class="invalid-feedback">')
+            html.append(f"\t\t\t{column} is required")
+            html.append("</div>")
+        else:
+            html.append(
+                f'<input type="text" class="typeahead form-control" name="{field_name}" '
+                + f'id="{field_name}-typeahead-obi"{value_html}>'
+            )
+
+    elif input_type.startswith("select"):
+        selects = input_type.split("(", 1)[1].rstrip(")").split(", ")
+        html.append(f'\t\t<select class="form-select" name="{field_name}">')
+        for s in selects:
+            if s == value:
+                html.append(f'\t\t\t<option value="{s}" selected>{s}</option>')
+            else:
+                html.append(f'\t\t\t<option value="{s}">{s}</option>')
+        html.append("\t\t</select>")
+
+    else:
+        return None
+
+    if help_msg:
+        html.append(f'\t\t<div class="form-text">{help_msg}</div>')
+    html.append("\t</div>")
+    html.append("</div>")
+    return html
+
+
+def build_form_html(fields, values=None, hidden=None):
+    html = []
+    if hidden:
+        for name, value in hidden.items():
+            html.append(f'<input type="hidden" name="{name}" value="{value}">')
+    for field, details in fields.items():
+        input_type = details.get("type")
+        value = None
+        if values:
+            value = values[field]
+        form_field = build_form_field(
+            input_type, field, details.get("help"), details.get("required"), value=value
+        )
+        if not form_field:
+            abort(500, f"Unknown input type '{input_type}' for column '{field}'")
+        html.extend(form_field)
+    return html
+
+
+def build_message(message_content):
+    """Return a pop-up message to display at the top of the page."""
+    message_type = "success"
+    if message_content.startswith("Unable"):
+        message_type = "danger"
+    message = f'<div class="alert alert-{message_type} alert-dismissible fade show" role="alert">\n'
+    message += f'<p class="mb-0">{message_content}</p>\n'
+    message += '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>\n'
+    message += "</div>\n"
+    return message
+
+
+def get_template_fields(template):
+    metadata_fields = {"ID": {"type": "text", "required": "true"}}
+    logic_fields = {}
+    with open(f"src/ontology/templates/{template}.tsv", "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        template_strings = next(reader)
+        for header, template in template_strings.items():
+            if template == "LABEL":
+                metadata_fields[header] = {"type": "text", "required": "true"}
+            elif template == "A definition":
+                metadata_fields[header] = {"type": "textarea", "required": "true"}
+            elif template.startswith("A"):
+                metadata_fields[header] = {"type": "text"}
+            elif template.strip() == "":
+                metadata_fields[header] = {"type": "text"}
+            else:
+                logic_fields[header] = {"type": "search"}
+    return metadata_fields, logic_fields
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("template")
+    parser.add_argument("branch")
+    parser.add_argument("message")
+    args = parser.parse_args()
+
+
+    metadata_fields, logic_fields = get_template_fields(args.template)
+    metadata_html = "\n".join(build_form_html(metadata_fields))
+    logic_html = "\n".join(build_form_html(logic_fields))
+    with open("src/scripts/form.html", "r") as f:
+        t = Template(f.read())
+        message = ""
+        if args.message != "None":
+            message = build_message(args.message)
+        html = t.render(title=args.template, message=message, branch=args.branch, metadata=metadata_html, logic=logic_html)
+        print(html)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/generate-form.sh
+++ b/src/scripts/generate-form.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# This simple CGI script helps create a tree browser for ONTIE
+
+cd ../..
+
+URL="http://example.com?${QUERY_STRING}"
+TEMPLATE=$(urlp --query --query_field=template "${URL}")
+ADD=$(urlp --query --query_field=add "${URL}")
+BRANCH=$(git branch --show-current)
+
+MESSAGE="None"
+if [[ ${ADD} ]]; then
+	QS=$(urlp --query "${URL}")
+	MESSAGE=$(python3 src/scripts/add-term.py "${QS}")
+fi
+
+echo "Content-Type: text/html"
+echo ""
+python3 src/scripts/generate-form.py ${TEMPLATE} ${BRANCH} "${MESSAGE}"


### PR DESCRIPTION
Add HTML forms generated from the templates to DROID. Also fix extra tabs in the disease template.

I should probably add a test step for this as well, since the current `validate` grabs the sheets from COGS. The whole `validate` pipeline is based on applying the errors to the Google sheet, so do we want a separate validation pipeline for this? I guess we have `make test` which just runs ROBOT report...

~Speaking of COGS, the `cogs.sh` doesn't seem to work anymore. I'll update this as well.~ This is working now.