### PR TITLE
Add protein tree annotation properties

### DIFF
--- a/ontie.owl
+++ b/ontie.owl
@@ -13,7 +13,7 @@
      xmlns:ontology="https://ontology.iedb.org/ontology/"
      xmlns:ncbitaxon="http://purl.obolibrary.org/obo/ncbitaxon#">
     <owl:Ontology rdf:about="https://ontology.iebd.org/ontology/ontie.owl">
-        <owl:versionIRI rdf:resource="https://ontology.iebd.org/ontology/2021-06-11/ontie.owl"/>
+        <owl:versionIRI rdf:resource="https://ontology.iebd.org/ontology/2021-06-16/ontie.owl"/>
         <dc:description>ONTIE is an application ontology for the IEDB Source of Truth that builds on reference resources including NCBI Taxonomy, MRO, OBI, UniProt, and GenPept.</dc:description>
         <dc:title>Ontology for Immune Epitopes</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
@@ -308,6 +308,54 @@
 
     <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003628">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has end position</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003629 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003629">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB assay ID</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003630 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003630">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB assay measurement of</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003631 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003631">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB assay synonym</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003632 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003632">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB assay technique</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003633 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003633">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB assay units</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003634 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003634">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB tree view name</rdfs:label>
     </owl:AnnotationProperty>
     
 

--- a/ontie.owl
+++ b/ontie.owl
@@ -240,6 +240,78 @@
     
 
 
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003620 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003620">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has sort name</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003621 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003621">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has taxonomic level</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003622 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003622">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein synonym</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003623 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003623">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has accession</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003624 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003624">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has accession IRI</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003625 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003625">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has source database</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003626 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003626">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has source ID</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003627 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003627">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has start position</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://ontology.iedb.org/ontology/ONTIE_0003628 -->
+
+    <owl:AnnotationProperty rdf:about="https://ontology.iedb.org/ontology/ONTIE_0003628">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has end position</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //

--- a/src/ontology/templates/predicates.tsv
+++ b/src/ontology/templates/predicates.tsv
@@ -34,6 +34,12 @@ ONTIE:0003625	has source database	owl:AnnotationProperty
 ONTIE:0003626	has source ID	owl:AnnotationProperty		
 ONTIE:0003627	has start position	owl:AnnotationProperty		
 ONTIE:0003628	has end position	owl:AnnotationProperty		
+ONTIE:0003629	IEDB assay ID	owl:AnnotationProperty		
+ONTIE:0003630	IEDB assay measurement of	owl:AnnotationProperty		
+ONTIE:0003631	IEDB assay synonym	owl:AnnotationProperty		
+ONTIE:0003632	IEDB assay technique	owl:AnnotationProperty		
+ONTIE:0003633	IEDB assay units	owl:AnnotationProperty		
+ONTIE:0003634	IEDB tree view name	owl:AnnotationProperty		
 owl:deprecated	obsolete	owl:AnnotationProperty	xsd:boolean	zero or one
 rdf:type	type	owl:AnnotationProperty	link	one or more
 rdfs:label	label	owl:AnnotationProperty		one

--- a/src/ontology/templates/predicates.tsv
+++ b/src/ontology/templates/predicates.tsv
@@ -25,6 +25,15 @@ ONTIE:0003616	NCBI Taxonomy browser	owl:AnnotationProperty
 ONTIE:0003617	has taxonomic rank	owl:AnnotationProperty		
 ONTIE:0003618	used in IEDB	owl:AnnotationProperty		
 ONTIE:0003619	has species	owl:AnnotationProperty		
+ONTIE:0003620	has sort name	owl:AnnotationProperty		
+ONTIE:0003621	has taxonomic level	owl:AnnotationProperty		
+ONTIE:0003622	protein synonym	owl:AnnotationProperty		
+ONTIE:0003623	has accession	owl:AnnotationProperty		
+ONTIE:0003624	has accession IRI	owl:AnnotationProperty		
+ONTIE:0003625	has source database	owl:AnnotationProperty		
+ONTIE:0003626	has source ID	owl:AnnotationProperty		
+ONTIE:0003627	has start position	owl:AnnotationProperty		
+ONTIE:0003628	has end position	owl:AnnotationProperty		
 owl:deprecated	obsolete	owl:AnnotationProperty	xsd:boolean	zero or one
 rdf:type	type	owl:AnnotationProperty	link	one or more
 rdfs:label	label	owl:AnnotationProperty		one


### PR DESCRIPTION
Adding some more annotation properties for the protein tree build. I may need more for the nonpeptide tree, so I'll keep this open for now.

ID | Label | Tree |
--- | --- | ---
ONTIE:0003620 | has sort name | protein, nonpeptide
ONTIE:0003621 | has taxonomic level | protein, organism
ONTIE:0003622 | protein synonym | protein
ONTIE:0003623 | has accession | protein
ONTIE:0003624 | has accession IRI | protein
ONTIE:0003625 | has source database | protein
ONTIE:0003626 | has source ID | protein
ONTIE:0003627 | has start position | protein
ONTIE:0003628 | has end position | protein
ONTIE:0003629 | IEDB assay ID | assay
ONTIE:0003630 | IEDB assay measurement of | assay
ONTIE:0003631 | IEDB assay synonym | assay
ONTIE:0003632 | IEDB assay technique | assay
ONTIE:0003633 | IEDB assay units | assay
ONTIE:0003634 | IEDB tree view name | assay