### PR TITLE
Fix adding terms via HTML form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,15 +75,22 @@ ontie.owl: $(TABLES) src/ontology/metadata.ttl build/imports.ttl | build/robot.j
 	--version-iri "https://ontology.iebd.org/ontology/$(DATE)/$@" \
 	--output $@
 
-build/report.%: ontie.owl | build/robot-report.jar
+build/ontie-base.owl: ontie.owl | build/robot-report.jar
 	$(ROBOT) remove \
 	--input $< \
 	--base-iri ONTIE \
 	--axioms external \
-	report \
-	--output $@ \
+	--output $@
+
+build/report.html: build/ontie-base.owl | build/robot-report.jar
+	$(ROBOT) report \
+	--input $< \
 	--standalone true \
-	--print 10
+	--fail-on none \
+	--output $@
+
+build/report.tsv: build/ontie-base.owl | build/robot-report.jar
+	$(ROBOT) report --input $< --print 10 --output $@
 
 build/diff.html: ontie.owl | build/robot.jar
 	git show master:ontie.owl > build/ontie.master.owl
@@ -169,7 +176,7 @@ build/ontie.db: src/scripts/prefixes.sql ontie.owl | build/rdftab
 
 .PHONY: update
 update:
-	make all dbs
+	make all dbs build/diff.html build/report.html
 
 .PHONY: clean
 clean:

--- a/src/ontology/templates/index.tsv
+++ b/src/ontology/templates/index.tsv
@@ -3596,13 +3596,13 @@ ONTIE:0003599	KZ52	owl:Class
 ONTIE:0003600	CR3022	owl:Class		
 ONTIE:0003601	convalescent plasma 1	owl:Class		
 ONTIE:0003602	convalescent plasma 2	owl:Class		
-ONTIE:0003603	negative plasma	owl:Class			
+ONTIE:0003603	negative plasma	owl:Class		
 ONTIE:0003604	prior pregnancy	owl:Class		
 ONTIE:0003605	family medical history	owl:Class		
 ONTIE:0003606	prenatal maternal abnormality	owl:Class		
 ONTIE:0003607	congenital disease	owl:Class		
 ONTIE:0003608	congenital urogenital anomaly	owl:Class		
-ONTIE:0003609	death status	owl:Class
+ONTIE:0003609	death status	owl:Class		
 ONTIE:0003611	ULOD (ng/mL)	owl:Class		
 ONTIE:0003612	LLOD (ng/mL)	owl:Class		
 ONTIE:0003613	MPI (%)	owl:Class		

--- a/src/scripts/add-term.py
+++ b/src/scripts/add-term.py
@@ -1,4 +1,5 @@
 import csv
+import sys
 
 from argparse import ArgumentParser
 from urllib.parse import parse_qs
@@ -30,13 +31,13 @@ def main():
 
 	if not template:
 		print("Unable to add term; missing template name")
-		return
+		sys.exit(1)
 	if not term_id:
 		print("Unable to add term; an ID is required")
-		return
+		sys.exit(1)
 	if not fields.get("Label"):
 		print("Unable to add term; a Label is required")
-		return
+		sys.exit(1)
 
 	template_path = f"src/ontology/templates/{template}.tsv"
 
@@ -49,12 +50,12 @@ def main():
 			if this_id == term_id:
 				this_label = row["Label"]
 				print(f"Unable to add term; a term already exists with ID {term_id} ({this_label})")
-				return
+				sys.exit(1)
 			rows.append(row)
 	rows.append({"ID": term_id, "Label": fields.get("Label"), "Type": "owl:Class"})
 
 	with open("src/ontology/templates/index.tsv", "w") as fw:
-		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n")
+		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n", extrasaction="ignore")
 		writer.writeheader()
 		writer.writerows(rows)
 
@@ -67,11 +68,11 @@ def main():
 	rows.append(fields)
 
 	with open(template_path, "w") as fw:
-		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n")
+		writer = csv.DictWriter(fw, delimiter="\t", fieldnames=header, lineterminator="\n", extrasaction="ignore")
 		writer.writeheader()
 		writer.writerows(rows)
 
-	print(f"{term_id} added to ONITE!")
+	print(f"{term_id} successfully added to ONITE!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An extra tab in `index.tsv` was causing the add-terms script to fail, but because it was embedded in a bash script, it failed silently. I fixed the tabs in the index file, but I also added code to `add-terms.py` to prevent this error from happening again if an extra tab is added.

Also update `Makefile` so that building the HTML report doesn't fail, as we want the user to see that page. I added the report and diff to the `update` task so the user doesn't have to see the "stale" page.