### PR TITLE
Remove old dependencies from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@
 # ### Before you go...
 # [Clean Build Directory](clean) [Destroy Google Sheet](destroy)
 
-KNODE := java -jar knode.jar
 ROBOT := java -jar build/robot.jar --prefix "ONTIE: https://ontology.iedb.org/ontology/ONTIE_"
-ROBOT_REPORT := java -jar build/robot-report.jar --prefix "ONTIE: https://ontology.iedb.org/ontology/ONTIE_"
 COGS := cogs
 
 DATE := $(shell date +%Y-%m-%d)
@@ -40,10 +38,7 @@ build build/validate build/diff build/master build/validation:
 	mkdir -p $@
 
 build/robot.jar: | build
-	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar
-
-build/robot-report.jar: | build
-	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/html-report/lastSuccessfulBuild/artifact/bin/robot.jar
+	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.9.0/robot.jar
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
@@ -75,7 +70,7 @@ ontie.owl: $(TABLES) src/ontology/metadata.ttl build/imports.ttl | build/robot.j
 	--version-iri "https://ontology.iedb.org/ontology/$(DATE)/$@" \
 	--output $@
 
-build/ontie-base.owl: ontie.owl | build/robot-report.jar
+build/ontie-base.owl: ontie.owl | build/robot.jar
 	$(ROBOT) remove \
 	--input $< \
 	--base-iri ONTIE \
@@ -156,9 +151,6 @@ refresh-imports: clean-imports build/imports.ttl
 
 
 # Tree Building
-
-build/robot-tree.jar: | build
-	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/tree-view/lastSuccessfulBuild/artifact/bin/robot.jar
 
 build/ontie.db: src/scripts/prefixes.sql ontie.owl | build/rdftab
 	rm -rf $@

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build/rdftab: | build
 
 # ROBOT templates from Google sheet
 
-SHEETS := predicates index external protein complex disease taxon assays other
+SHEETS := predicates index external protein complex disease taxon assays other obsolete
 TABLES := $(foreach S,$(SHEETS),src/ontology/templates/$(S).tsv)
 
 # ONTIE from templates

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,14 @@ build/ontie-base.owl: ontie.owl | build/robot.jar
 	--axioms external \
 	--output $@
 
-build/report.html: build/ontie-base.owl | build/robot-report.jar
+build/report.html: build/ontie-base.owl | build/robot.jar
 	$(ROBOT) report \
 	--input $< \
 	--standalone true \
 	--fail-on none \
 	--output $@
 
-build/report.tsv: build/ontie-base.owl | build/robot-report.jar
+build/report.tsv: build/ontie-base.owl | build/robot.jar
 	$(ROBOT) report --input $< --print 10 --output $@
 
 build/diff.html: ontie.owl | build/robot.jar

--- a/ontie.owl
+++ b/ontie.owl
@@ -13,7 +13,7 @@
      xmlns:ontology="https://ontology.iedb.org/ontology/"
      xmlns:ncbitaxon="http://purl.obolibrary.org/obo/ncbitaxon#">
     <owl:Ontology rdf:about="https://ontology.iedb.org/ontology/ontie.owl">
-        <owl:versionIRI rdf:resource="https://ontology.iedb.org/ontology/2022-06-28/ontie.owl"/>
+        <owl:versionIRI rdf:resource="https://ontology.iedb.org/ontology/2022-08-15/ontie.owl"/>
         <dc:description>ONTIE is an application ontology for the IEDB Source of Truth that builds on reference resources including NCBI Taxonomy, MRO, OBI, UniProt, and GenPept.</dc:description>
         <dc:title>Ontology for Immune Epitopes</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
@@ -44561,13 +44561,6 @@
     <!-- https://ontology.iedb.org/ontology/ONTIE_0002666 -->
 
     <owl:Class rdf:about="https://ontology.iedb.org/ontology/ONTIE_0002666">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_520"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IAP S1</obo:IAO_0000118>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Islet-activating protein S1</obo:IAO_0000118>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NAD-dependent ADP-ribosyltransferase</obo:IAO_0000118>
@@ -44575,9 +44568,8 @@
         <obo:IAO_0000234 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB</obo:IAO_0000234>
         <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/PR_P04977"/>
         <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 1</obo:OBI_9991118>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 1 (Bordetella pertussis)</rdfs:label>
-        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</owl:deprecated>
-        <ontology:ONTIE_0003259 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein</ontology:ONTIE_0003259>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete pertussis toxin subunit 1 (Bordetella pertussis)</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -50100,19 +50092,11 @@
     <!-- https://ontology.iedb.org/ontology/ONTIE_0002950 -->
 
     <owl:Class rdf:about="https://ontology.iedb.org/ontology/ONTIE_0002950">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_520"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000234 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB</obo:IAO_0000234>
         <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/PR_P0A3R5"/>
         <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pertussis toxin subunit 4</obo:OBI_9991118>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pertussis toxin subunit 4 (Bordetella pertussis)</rdfs:label>
-        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</owl:deprecated>
-        <ontology:ONTIE_0003259 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein</ontology:ONTIE_0003259>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete pertussis toxin subunit 4 (Bordetella pertussis)</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 

--- a/src/ontology/templates/index.tsv
+++ b/src/ontology/templates/index.tsv
@@ -2665,7 +2665,7 @@ ONTIE:0002662	Low-density lipoprotein receptor (Homo sapiens)	owl:Class			IEDB
 ONTIE:0002663	Insulin (Bos taurus)	owl:Class			IEDB
 ONTIE:0002664	Membrane protein, putative (Coxiella burnetii)	owl:Class			IEDB
 ONTIE:0002665	Hemagglutinin-neuraminidase (Avian orthoavulavirus 1)	owl:Class			IEDB
-ONTIE:0002666	Pertussis toxin subunit 1 (Bordetella pertussis)	owl:Class	TRUE	PR:P04977	IEDB
+ONTIE:0002666	obsolete pertussis toxin subunit 1 (Bordetella pertussis)	owl:Class	true	PR:P04977	IEDB
 ONTIE:0002667	Chaperone protein ClpB (Escherichia coli)	owl:Class			IEDB
 ONTIE:0002668	Secretion protein (Francisella tularensis)	owl:Class			IEDB
 ONTIE:0002669	Membrane protein (Severe acute respiratory syndrome-related coronavirus)	owl:Class			IEDB
@@ -2949,7 +2949,7 @@ ONTIE:0002946	DNA helicase INO80 (Mus musculus)	owl:Class			IEDB
 ONTIE:0002947	progesterone receptor (Mus musculus)	owl:Class			IEDB
 ONTIE:0002948	SET binding factor 1 (Homo sapiens)	owl:Class			IEDB
 ONTIE:0002949	bullous pemphigoid antigen (Homo sapiens)	owl:Class			IEDB
-ONTIE:0002950	pertussis toxin subunit 4 (Bordetella pertussis)	owl:Class	TRUE	PR:P0A3R5	IEDB
+ONTIE:0002950	obsolete pertussis toxin subunit 4 (Bordetella pertussis)	owl:Class	true	PR:P0A3R5	IEDB
 ONTIE:0002951	E1A 26 kDa protein (Human adenovirus 5)	owl:Class			IEDB
 ONTIE:0002952	Clostridium Neurotoxin Type B (Clostridium botulinum)	owl:Class			IEDB
 ONTIE:0002953	Major Peanut Allergen Ara H 1 (Arachis hypogaea)	owl:Class			IEDB

--- a/src/ontology/templates/obsolete.tsv
+++ b/src/ontology/templates/obsolete.tsv
@@ -1,0 +1,7 @@
+Label	Alternative Term	IEDB Term	Domain
+LABEL	A alternative term SPLIT=|	A IEDB alternative term SPLIT=|	
+obsolete lactate dehydrogenase (Papio cynocephalus)			
+obsolete Large structural phosphoprotein (Human betaherpesvirus 5)			
+obsolete pertussis toxin subunit 1 (Bordetella pertussis)	IAP S1|Islet-activating protein S1|NAD-dependent ADP-ribosyltransferase|PTX S1	Pertussis toxin subunit 1	protein
+obsolete pertussis toxin subunit 4 (Bordetella pertussis)		pertussis toxin subunit 4	protein
+obsolete US22 family homolog (Murid betaherpesvirus 1)			

--- a/src/ontology/templates/protein.tsv
+++ b/src/ontology/templates/protein.tsv
@@ -972,8 +972,6 @@ Peptide ABC transporter, permease protein, putative (Coxiella burnetii)	protein	
 Peptide chain release factor 3 (Coxiella burnetii)	protein	RF-3	Peptide chain release factor 3	protein	Coxiella burnetii
 periodic tryptophan protein 2 homolog (Homo sapiens)	protein		periodic tryptophan protein 2 homolog	protein	Homo sapiens
 permease (Leptospira interrogans)	protein		permease	protein	Leptospira interrogans
-Pertussis toxin subunit 1 (Bordetella pertussis)	protein	IAP S1|Islet-activating protein S1|NAD-dependent ADP-ribosyltransferase|PTX S1	Pertussis toxin subunit 1	protein	Bordetella pertussis
-pertussis toxin subunit 4 (Bordetella pertussis)	protein		pertussis toxin subunit 4	protein	Bordetella pertussis
 PH and SEC7 domain-containing protein 4 (Homo sapiens)	protein		PH and SEC7 domain-containing protein 4	protein	Homo sapiens
 phage baseplate protein (Salmonella enterica)	protein		phage baseplate protein	protein	Salmonella enterica
 Phl p 3 allergen (Phleum pratense)	protein		Phl p 3 allergen	protein	Phleum pratense


### PR DESCRIPTION
Fixes #72﻿

Updating to ROBOT 1.9.0 revealed problems with the obsoletion of two proteins, so I also fixed that here.